### PR TITLE
chore: .env로 msw 모드를 끌 수 있도록 처리한다.

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,18 +11,20 @@ import router from "./app/router";
 import { worker } from "./mocks/browser";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RecoilRoot } from "recoil";
-import './configs/recoil';
+import "./configs/recoil";
 
 const queryClient = new QueryClient();
 
 async function main() {
   // msw 세팅 시작
-  await worker.start({
-    serviceWorker: {
-      url: "/fin-the-pen-web/mockServiceWorker.js",
-    },
-    onUnhandledRequest: "bypass",
-  });
+  if (import.meta.env.VITE_LOCAL_MODE !== "true") {
+    await worker.start({
+      serviceWorker: {
+        url: "/fin-the-pen-web/mockServiceWorker.js",
+      },
+      onUnhandledRequest: "bypass",
+    });
+  }
   // msw 세팅 끝
 
   const root = ReactDOM.createRoot(


### PR DESCRIPTION
로컬 서버와 연결하여 실행하는 방법

1. 루트 폴더에 `.env.local`을 추가합니다.
2. `VITE_LOCAL_MODE=true`을 입력하고 저장합니다.

VITE_LOCAL_MODE가 true 이외의 값이거나 .env.local 파일이 존재하지 않는 경우에는 msw가 기본적으로 실행됩니다.

----

프로젝트에 많은 시간을 쓰지 못해서 이것 부터 빠르게 처리합니다.

과거 코드로 복구 예정인데 우선 급한 것 부터 처리합니다.