### PR TITLE
feat: scheduleDrawer에 confirm 추가

### DIFF
--- a/src/containers/home/ScheduleDrawer/ScheduleDrawer.tsx
+++ b/src/containers/home/ScheduleDrawer/ScheduleDrawer.tsx
@@ -10,6 +10,7 @@ import ScheduleFormPage from "@containers/home/ScheduleDrawer/pages/ScheduleForm
 import CategoryPicker from "@containers/home/ScheduleDrawer/pages/ScheduleFormPage/components/CategoryPicker";
 import RepeatPicker from "@containers/home/ScheduleDrawer/pages/ScheduleFormPage/components/RepeatPicker";
 import useSchedule from "@hooks/useSchedule";
+import { useConfirm } from "@hooks/dialog/hooks/useConfirm";
 
 function TransitionUp(props: SlideProps) {
   return <Slide {...props} direction="right" />;
@@ -32,15 +33,24 @@ function ScheduleDrawer({ setDrawerWidth, handleClose }: ScheduleDrawerProps) {
   const [isRepeatPickerOpen, setIsRepeatPickerOpen] = useState(false);
 
   const { resetSchedule } = useSchedule();
+  const { openConfirm } = useConfirm();
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     swiper?.slideTo(newValue);
     setValue(newValue);
   };
 
-  const handleReset = () => {
-    setShowError(false);
-    resetSchedule();
+  const handleReset = async () => {
+    const answer = await openConfirm({
+      title: "알림",
+      content: "입력 정보를 초기화하시겠습니까?",
+      approveText: "네",
+      rejectText: "아니오",
+    });
+    if (answer) {
+      setShowError(false);
+      resetSchedule();
+    }
   };
 
   const ref = useRef<HTMLDivElement>(null);

--- a/src/containers/home/ScheduleDrawer/pages/AssetFormPage/SpendingInput.tsx
+++ b/src/containers/home/ScheduleDrawer/pages/AssetFormPage/SpendingInput.tsx
@@ -14,9 +14,11 @@ import { useState } from "react";
 import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import RemoveRoundedIcon from "@mui/icons-material/RemoveRounded";
 import { useScheduleForm } from "@containers/home/ScheduleDrawer/hooks/useScheduleForm.ts";
+import { useConfirm } from "@hooks/dialog/hooks/useConfirm.tsx";
 
 function SpendingInput() {
   const { scheduleForm, updateSchedule } = useScheduleForm();
+  const { openConfirm } = useConfirm();
   const expectedSpending = scheduleForm ? scheduleForm?.amount : "0";
   const [showError, setShowError] = useState(false);
 
@@ -41,9 +43,20 @@ function SpendingInput() {
     });
   };
 
-  const changeFixAmount = (state: UpdateStateInterface) => {
-    updateSchedule(state);
+  const changeFixAmount = async (state: UpdateStateInterface) => {
+    const answer =
+      !scheduleForm?.fix_amount ||
+      (await openConfirm({
+        title: "알림",
+        content: "금액 고정을 해제하시겠습니까?",
+        approveText: "네",
+        rejectText: "아니오",
+      }));
+    if (answer) {
+      updateSchedule(state);
+    }
   };
+
   return (
     <Stack spacing={2} px={2.5}>
       <Box sx={{ typography: "h4", color: "primary.main" }}>

--- a/src/containers/home/ScheduleDrawer/pages/AssetFormPage/SpendingInput.tsx
+++ b/src/containers/home/ScheduleDrawer/pages/AssetFormPage/SpendingInput.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   FormControl,
   FormHelperText,
-  Grid,
   InputBase,
   Stack,
   Typography,
@@ -46,52 +45,48 @@ function SpendingInput() {
     updateSchedule(state);
   };
   return (
-    <Grid container spacing={2} px={2.5}>
-      <Grid item xs={12} sx={{ typography: "h4", color: "primary.main" }}>
+    <Stack spacing={2} px={2.5}>
+      <Box sx={{ typography: "h4", color: "primary.main" }}>
         {SCHEDULE_DRAWER.set_spending_title}
-      </Grid>
+      </Box>
 
-      <Grid item container spacing={1.5}>
-        <Grid item xs={6}>
-          <Button
-            variant={
-              scheduleForm?.price_type === SCHEDULE_DRAWER.type_minus
-                ? "contained"
-                : "outlined"
-            }
-            fullWidth
-            id="price_type"
-            value={SCHEDULE_DRAWER.type_minus}
-            onClick={changeSchedule}
-            sx={{
-              borderRadius: "20px",
-            }}
-          >
-            출금
-          </Button>
-        </Grid>
+      <Stack direction="row" spacing={1.5}>
+        <Button
+          variant={
+            scheduleForm?.price_type === SCHEDULE_DRAWER.type_minus
+              ? "contained"
+              : "outlined"
+          }
+          fullWidth
+          id="price_type"
+          value={SCHEDULE_DRAWER.type_minus}
+          onClick={changeSchedule}
+          sx={{
+            borderRadius: "20px",
+          }}
+        >
+          출금
+        </Button>
 
-        <Grid item xs={6}>
-          <Button
-            variant={
-              scheduleForm?.price_type === SCHEDULE_DRAWER.type_plus
-                ? "contained"
-                : "outlined"
-            }
-            fullWidth
-            id="price_type"
-            value={SCHEDULE_DRAWER.type_plus}
-            onClick={changeSchedule}
-            sx={{
-              borderRadius: "20px",
-            }}
-          >
-            입금
-          </Button>
-        </Grid>
-      </Grid>
+        <Button
+          variant={
+            scheduleForm?.price_type === SCHEDULE_DRAWER.type_plus
+              ? "contained"
+              : "outlined"
+          }
+          fullWidth
+          id="price_type"
+          value={SCHEDULE_DRAWER.type_plus}
+          onClick={changeSchedule}
+          sx={{
+            borderRadius: "20px",
+          }}
+        >
+          입금
+        </Button>
+      </Stack>
 
-      <Grid item xs={12}>
+      <Box>
         <FormControl fullWidth>
           <Stack
             direction="row"
@@ -142,33 +137,27 @@ function SpendingInput() {
             {showError ? "입력 금액이 범위를 초과했습니다!" : ""}
           </FormHelperText>
         </FormControl>
-      </Grid>
+      </Box>
 
-      <Grid item xs={12}>
-        <Stack
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
-        >
-          <Typography variant="h4" sx={{ color: "primary.main" }}>
-            {SCHEDULE_DRAWER.fix_amount}
-          </Typography>
-          <Stack direction="row" alignItems="center">
-            <SwitchButton
-              checked={scheduleForm?.fix_amount ?? false}
-              handleChange={() =>
-                changeFixAmount({
-                  target: {
-                    id: "fix_amount",
-                    value: !scheduleForm?.fix_amount,
-                  },
-                })
-              }
-            />
-          </Stack>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="h4" sx={{ color: "primary.main" }}>
+          {SCHEDULE_DRAWER.fix_amount}
+        </Typography>
+        <Stack direction="row" alignItems="center">
+          <SwitchButton
+            checked={scheduleForm?.fix_amount ?? false}
+            handleChange={() =>
+              changeFixAmount({
+                target: {
+                  id: "fix_amount",
+                  value: !scheduleForm?.fix_amount,
+                },
+              })
+            }
+          />
         </Stack>
-      </Grid>
-    </Grid>
+      </Stack>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
scheduleDrawer에서 확인이 필요한 초기화, 금액 고정 해제에 openConfirm을 추가했습니다.

추가적으로 grid로 감싸져 있던 SpendingInput 컴포넌트를 Stack으로 변경해 디자인이 깨지는 문제를 해결했습니다.

close #172