### PR TITLE
refactor: 일정 CRUD api 변동에 맞게 로직을 수정합니다.

### DIFF
--- a/src/app/tanstack-query/schedules/useDeleteSchedule.ts
+++ b/src/app/tanstack-query/schedules/useDeleteSchedule.ts
@@ -1,0 +1,55 @@
+import { SESSION_STORAGE_KEY_TOKEN } from "@api/keys";
+import { DOMAIN } from "@api/url";
+import { getSessionStorage } from "@app/utils/storage";
+import { QUERY_KEY_SCHEDULES } from "@constants/queryKeys";
+import { getSign } from "@components/ScheduleDrawer/hooks/useScheduleForm";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Schedule } from "@app/types/schedule.ts";
+import moment from "moment";
+
+interface PropsInterface {
+  schedule: Schedule;
+  delete_options: string;
+  user_id: string;
+}
+
+const fetchDeleteSchedule = async ({
+  schedule,
+  delete_options,
+  user_id,
+}: PropsInterface) => {
+  const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
+  const data = { schedule_id: schedule.id, delete_options, user_id };
+
+  return fetch(`${DOMAIN}/deleteSchedule`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer " + token,
+    },
+    body: JSON.stringify(data),
+  });
+};
+
+export const useDeleteSchedule = () => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationFn: fetchDeleteSchedule,
+    onSuccess: async (data, variables) => {
+      const date = moment(variables.schedule.start_date);
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY_SCHEDULES, date.format("YYYY-MM")],
+      });
+    },
+  });
+
+  const deleteSchedule = (
+    schedule: Schedule,
+    delete_options: string,
+    user_id: string
+  ) => {
+    mutate({ schedule, delete_options, user_id });
+  };
+
+  return { deleteSchedule };
+};

--- a/src/app/tanstack-query/schedules/useModifySchedule.ts
+++ b/src/app/tanstack-query/schedules/useModifySchedule.ts
@@ -11,6 +11,7 @@ interface PropsInterface {
   schedule: Schedule;
   option: string;
 }
+
 const fetchModifySchedule = async ({ schedule, option }: PropsInterface) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
   const data = {
@@ -21,7 +22,7 @@ const fetchModifySchedule = async ({ schedule, option }: PropsInterface) => {
     exclusion: schedule.exclude,
     price_type: getSign(schedule.price_type),
     schedule_id: schedule.id,
-    repeat: { ...schedule.repeat, kind_type: "day" }, // api 수정 후 삭제
+    repeat: { ...schedule.repeat }, // api 수정 후 삭제
     modify_options: option, // all:모두 , nowFromOption: 이후 일정, exceptNowAfter: 현재 일정 제외 이후 일정
   };
 

--- a/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/ScheduleChangeModal.stories.tsx
+++ b/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/ScheduleChangeModal.stories.tsx
@@ -1,0 +1,47 @@
+import { Meta } from "@storybook/react";
+import { useState } from "react";
+import { Button, Divider, Typography } from "@mui/material";
+import { useScheduleChangeModal } from "@components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx";
+
+export const Example = () => {
+  const { openModal } = useScheduleChangeModal();
+  const [modifyValue, setModifyValue] =
+    useState("버튼을 눌러 업데이트 해주세요");
+  const [deleteValue, setDeleteValue] =
+    useState("버튼을 눌러 업데이트 해주세요");
+
+  const handleDelete = async () => {
+    const answer = await openModal({
+      changeMode: "삭제",
+    });
+    setDeleteValue(answer);
+  };
+
+  const handleModify = async () => {
+    const answer = await openModal({
+      changeMode: "수정",
+    });
+    setModifyValue(answer);
+  };
+
+  return (
+    <>
+      <Typography>선택된 수정 옵션 : {modifyValue}</Typography>
+      <Button variant="contained" color="info" onClick={handleModify}>
+        modify
+      </Button>
+      <Divider sx={{ borderWidth: "2px", margin: "8px" }} />
+      <Typography>선택된 삭제 옵션 : {deleteValue}</Typography>
+      <Button variant="contained" color="error" onClick={handleDelete}>
+        delete
+      </Button>
+    </>
+  );
+};
+
+const meta = {
+  title: "ui/ScheduleDrawer/hooks/useChangeModal",
+  component: Example,
+} satisfies Meta<typeof Example>;
+
+export default meta;

--- a/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/ScheduleChangeModal.tsx
+++ b/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/ScheduleChangeModal.tsx
@@ -1,0 +1,72 @@
+import {
+  Box,
+  Button,
+  Dialog as MuiDialog,
+  Divider,
+  Stack,
+  Typography,
+} from "@mui/material";
+import CloseOutlinedIcon from "@mui/icons-material/CloseOutlined";
+
+export interface ScheduleChangeModalProps {
+  changeMode: "수정" | "삭제";
+  onClickReject: () => void;
+  onClickOnlyNow: () => void;
+  onClickAll: () => void;
+  onClickNowFromAfter: () => void;
+}
+
+function ScheduleChangeModal({
+  changeMode,
+  onClickReject,
+  onClickOnlyNow,
+  onClickAll,
+  onClickNowFromAfter,
+}: ScheduleChangeModalProps) {
+  return (
+    <MuiDialog
+      sx={{ "& .MuiDialog-paper": { borderRadius: "1rem", width: "100%" } }}
+      open={true}
+      scroll="body"
+    >
+      <Stack p="20px">
+        <Stack
+          direction="row"
+          alignItems="center"
+          justifyContent="space-between"
+          mb={2}
+        >
+          <Box width={"24px"} />
+          <Typography variant="h1" sx={{ fontWeight: "bold" }}>
+            {`일정 ${changeMode}`}
+          </Typography>
+          <CloseOutlinedIcon onClick={onClickReject} />
+        </Stack>
+        <Divider sx={{ backgroundColor: "black", height: "1px" }} />
+        <Stack spacing={1.5} pt={3}>
+          <Typography variant="h4" textAlign="center">
+            <span style={{ fontWeight: 700 }}>선택한 일정</span>
+            {`을 ${changeMode}합니다.`}
+          </Typography>
+          <Button
+            onClick={onClickOnlyNow}
+            variant="outlined"
+            color="error"
+          >{`선택 일정만 ${changeMode}`}</Button>
+          <Button
+            onClick={onClickAll}
+            variant="outlined"
+            color="error"
+          >{`전체 일정 ${changeMode}`}</Button>
+          <Button
+            onClick={onClickNowFromAfter}
+            variant="outlined"
+            color="error"
+          >{`현재 일정 및 이후 일정 ${changeMode}`}</Button>
+        </Stack>
+      </Stack>
+    </MuiDialog>
+  );
+}
+
+export default ScheduleChangeModal;

--- a/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx
+++ b/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx
@@ -8,13 +8,13 @@ export const useScheduleChangeModal = () => {
     changeMode,
   }: {
     changeMode: "수정" | "삭제";
-  }): Promise<string> => {
+  }): Promise<string | boolean> => {
     return new Promise((resolve) => {
       openOverlay(
         <ScheduleChangeModal
           changeMode={changeMode}
           onClickReject={() => {
-            resolve("");
+            resolve(false);
             closeOverlay();
           }}
           onClickOnlyNow={() => {

--- a/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx
+++ b/src/components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx
@@ -1,0 +1,38 @@
+import { useOverlay } from "@hooks/use-overlay/useOverlay.tsx";
+import ScheduleChangeModal from "@components/ScheduleDrawer/hooks/ScheduleChangeModal/ScheduleChangeModal.tsx";
+
+export const useScheduleChangeModal = () => {
+  const { openOverlay, closeOverlay } = useOverlay();
+
+  const openModal = ({
+    changeMode,
+  }: {
+    changeMode: "수정" | "삭제";
+  }): Promise<string> => {
+    return new Promise((resolve) => {
+      openOverlay(
+        <ScheduleChangeModal
+          changeMode={changeMode}
+          onClickReject={() => {
+            resolve("");
+            closeOverlay();
+          }}
+          onClickOnlyNow={() => {
+            resolve("exceptNowAfter");
+            closeOverlay();
+          }}
+          onClickAll={() => {
+            resolve("all");
+            closeOverlay();
+          }}
+          onClickNowFromAfter={() => {
+            resolve("nowFromAfter");
+            closeOverlay();
+          }}
+        />
+      );
+    });
+  };
+
+  return { openModal };
+};

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
@@ -27,7 +27,7 @@ function CreateFooter({ handleSubmit, handleClose }: CreateFooterInterface) {
 
   const handleCreate = () => {
     if (handleSubmit()) {
-      handleCreateSchedule(schedule, date);
+      handleCreateSchedule(schedule);
       handleClose();
     }
   };

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/ModifyFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/ModifyFooter.tsx
@@ -4,6 +4,7 @@ import { SCHEDULE_DRAWER } from "@constants/schedule.ts";
 import useSchedule from "@hooks/useSchedule.ts";
 import { Button, Stack } from "@mui/material";
 import { Schedule } from "@app/types/schedule.ts";
+import { useScheduleChangeModal } from "@components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx";
 
 interface ModifyFooterInterface {
   handleSubmit: () => boolean;
@@ -13,10 +14,14 @@ interface ModifyFooterInterface {
 function ModifyFooter({ handleSubmit, handleClose }: ModifyFooterInterface) {
   const schedule = useAppSelector(selectScheduleForm) as Schedule;
   const { handleModifySchedule, handleDeleteSchedule } = useSchedule();
+  const { openModal } = useScheduleChangeModal();
 
-  const handleModify = () => {
+  const handleModify = async () => {
     if (handleSubmit()) {
-      handleModifySchedule(schedule);
+      const answer = await openModal({
+        changeMode: "수정",
+      });
+      handleModifySchedule(schedule, answer);
       handleClose();
     }
   };

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/ModifyFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/ModifyFooter.tsx
@@ -24,7 +24,7 @@ function ModifyFooter({ handleSubmit, handleClose }: ModifyFooterInterface) {
   };
 
   const handleDelete = () => {
-    handleDeleteSchedule(schedule.id ?? "");
+    handleDeleteSchedule(schedule);
     handleClose();
   };
 

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/ModifyFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/ModifyFooter.tsx
@@ -16,12 +16,9 @@ function ModifyFooter({ handleSubmit, handleClose }: ModifyFooterInterface) {
   const { handleModifySchedule, handleDeleteSchedule } = useSchedule();
   const { openModal } = useScheduleChangeModal();
 
-  const handleModify = async () => {
+  const handleModify = () => {
     if (handleSubmit()) {
-      const answer = await openModal({
-        changeMode: "수정",
-      });
-      handleModifySchedule(schedule, answer);
+      handleModifySchedule(schedule);
       handleClose();
     }
   };

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/RepeatPicker/RepeatPicker.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/RepeatPicker/RepeatPicker.tsx
@@ -26,7 +26,7 @@ function RepeatPicker({ setIsRepeatPickerOpen }: RepeatPickerProps) {
   };
 
   return (
-    <>
+    <Box minHeight="562px">
       <TopNavigationBar
         onClick={() => setIsRepeatPickerOpen(false)}
         title="반복 설정"
@@ -52,7 +52,7 @@ function RepeatPicker({ setIsRepeatPickerOpen }: RepeatPickerProps) {
           />
         </>
       )}
-    </>
+    </Box>
   );
 }
 

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -14,6 +14,7 @@ import { useSchedules } from "@app/tanstack-query/schedules/useSchedules.ts";
 import { INIT_SCHEDULE } from "@constants/schedule.ts";
 import { useModifySchedule } from "@app/tanstack-query/schedules/useModifySchedule.ts";
 import { useDialog } from "@hooks/dialog/useDialog.tsx";
+import { useScheduleChangeModal } from "@components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx";
 
 const useSchedule = () => {
   const dispatch = useAppDispatch();
@@ -23,6 +24,7 @@ const useSchedule = () => {
 
   const { data: user } = useUser();
   const { openConfirm } = useDialog();
+  const { openModal } = useScheduleChangeModal();
   const { createSchedule } = useCreateSchedule();
   const { modifySchedule } = useModifySchedule();
   const {
@@ -75,8 +77,13 @@ const useSchedule = () => {
     }
   };
 
-  const handleModifySchedule = async (schedule: Schedule, option: string) => {
-    modifySchedule(schedule, option);
+  const handleModifySchedule = async (schedule: Schedule) => {
+    const answer = await openModal({
+      changeMode: "수정",
+    });
+    if (answer) {
+      modifySchedule(schedule, answer as string);
+    }
   };
 
   const resetSchedule = () => {

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -13,7 +13,6 @@ import { useUser } from "@app/tanstack-query/useUser.ts";
 import { useSchedules } from "@app/tanstack-query/schedules/useSchedules.ts";
 import { INIT_SCHEDULE } from "@constants/schedule.ts";
 import { useModifySchedule } from "@app/tanstack-query/schedules/useModifySchedule.ts";
-import { useDialog } from "@hooks/dialog/useDialog.tsx";
 import { useScheduleChangeModal } from "@components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx";
 import { useDeleteSchedule } from "@app/tanstack-query/schedules/useDeleteSchedule.ts";
 
@@ -24,7 +23,6 @@ const useSchedule = () => {
   const month = useSelector(selectMonth);
 
   const { data: user } = useUser();
-  const { openConfirm } = useDialog();
   const { openModal } = useScheduleChangeModal();
   const { createSchedule } = useCreateSchedule();
   const { modifySchedule } = useModifySchedule();

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -75,8 +75,8 @@ const useSchedule = () => {
     }
   };
 
-  const handleModifySchedule = async (schedule: Schedule) => {
-    modifySchedule(schedule);
+  const handleModifySchedule = async (schedule: Schedule, option: string) => {
+    modifySchedule(schedule, option);
   };
 
   const resetSchedule = () => {

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -15,6 +15,7 @@ import { INIT_SCHEDULE } from "@constants/schedule.ts";
 import { useModifySchedule } from "@app/tanstack-query/schedules/useModifySchedule.ts";
 import { useDialog } from "@hooks/dialog/useDialog.tsx";
 import { useScheduleChangeModal } from "@components/ScheduleDrawer/hooks/ScheduleChangeModal/useScheduleChangeModal.tsx";
+import { useDeleteSchedule } from "@app/tanstack-query/schedules/useDeleteSchedule.ts";
 
 const useSchedule = () => {
   const dispatch = useAppDispatch();
@@ -27,6 +28,7 @@ const useSchedule = () => {
   const { openModal } = useScheduleChangeModal();
   const { createSchedule } = useCreateSchedule();
   const { modifySchedule } = useModifySchedule();
+  const { deleteSchedule } = useDeleteSchedule();
   const {
     data: schedules,
     isPending,
@@ -61,19 +63,23 @@ const useSchedule = () => {
     createSchedule(scheduleWithUuid);
   };
 
-  const handleDeleteSchedule = async (scheduleId: string) => {
-    const answer = await openConfirm({
-      title: "일정 삭제",
-      content: "정말로 삭제 하시겠습니까?",
-      approveText: "삭제",
-      rejectText: "취소",
+  const handleDeleteSchedule = async (schedule: Schedule) => {
+    // const answer = await openConfirm({
+    //   title: "일정 삭제",
+    //   content: "정말로 삭제 하시겠습니까?",
+    //   approveText: "삭제",
+    //   rejectText: "취소",
+    // });
+    const answer = await openModal({
+      changeMode: "삭제",
     });
-    if (answer) {
-      console.log(scheduleId);
-      alert(
-        "아직 구현 안됨. useMutation으로 수정해주세요. scheduleId: " +
-          scheduleId
-      );
+    if (answer && user) {
+      // console.log(scheduleId);
+      // alert(
+      //   "아직 구현 안됨. useMutation으로 수정해주세요. scheduleId: " +
+      //     scheduleId
+      // );
+      deleteSchedule(schedule, answer as string, user.user_id);
     }
   };
 

--- a/src/hooks/useSchedule.ts
+++ b/src/hooks/useSchedule.ts
@@ -45,14 +45,10 @@ const useSchedule = () => {
         moment(date).isSameOrBefore(schedule.end_date)
     ) ?? [];
 
-  const handleCreateSchedule = async (
-    schedule: Schedule,
-    stringDate: string
-  ) => {
+  const handleCreateSchedule = async (schedule: Schedule) => {
     if (user === undefined) {
       return alert("로그인이 필요합니다.");
     }
-    const date = moment(stringDate);
 
     const scheduleWithUuid = {
       ...schedule,
@@ -64,21 +60,10 @@ const useSchedule = () => {
   };
 
   const handleDeleteSchedule = async (schedule: Schedule) => {
-    // const answer = await openConfirm({
-    //   title: "일정 삭제",
-    //   content: "정말로 삭제 하시겠습니까?",
-    //   approveText: "삭제",
-    //   rejectText: "취소",
-    // });
     const answer = await openModal({
       changeMode: "삭제",
     });
     if (answer && user) {
-      // console.log(scheduleId);
-      // alert(
-      //   "아직 구현 안됨. useMutation으로 수정해주세요. scheduleId: " +
-      //     scheduleId
-      // );
       deleteSchedule(schedule, answer as string, user.user_id);
     }
   };

--- a/src/hooks/useScheduleDrawer.tsx
+++ b/src/hooks/useScheduleDrawer.tsx
@@ -1,9 +1,11 @@
 import { useOverlay } from "@hooks/use-overlay/useOverlay.tsx";
 import { Schedule } from "@app/types/schedule.ts";
-import { SwipeableDrawer } from "@mui/material";
+import { styled, SwipeableDrawer } from "@mui/material";
 import ScheduleDrawer from "@components/ScheduleDrawer";
 import { setDrawerScheduleForm } from "@redux/slices/scheduleSlice.tsx";
 import { useAppDispatch } from "@redux/hooks.ts";
+import CssBaseline from "@mui/material/CssBaseline";
+import { grey } from "@mui/material/colors";
 
 export const useScheduleDrawer = () => {
   const { openOverlay, closeOverlay } = useOverlay();
@@ -11,21 +13,29 @@ export const useScheduleDrawer = () => {
   const toggleDrawer = (newOpen: boolean) => () => {
     !newOpen && closeOverlay();
   };
+
+  const Root = styled("div")(({ theme }) => ({
+    height: "100%",
+  }));
+
   const openScheduleDrawer = (data: Schedule) => {
     dispatch(setDrawerScheduleForm(data));
     openOverlay(
-      <SwipeableDrawer
-        anchor="bottom"
-        open={true}
-        onClose={toggleDrawer(false)}
-        onOpen={toggleDrawer(true)}
-        disableSwipeToOpen={true}
-        ModalProps={{
-          keepMounted: true,
-        }}
-      >
-        <ScheduleDrawer handleClose={closeOverlay} />
-      </SwipeableDrawer>
+      <Root>
+        <CssBaseline />
+        <SwipeableDrawer
+          anchor="bottom"
+          open={true}
+          onClose={toggleDrawer(false)}
+          onOpen={toggleDrawer(true)}
+          disableSwipeToOpen={true}
+          ModalProps={{
+            keepMounted: true,
+          }}
+        >
+          <ScheduleDrawer handleClose={closeOverlay} />
+        </SwipeableDrawer>
+      </Root>
     );
   };
 

--- a/src/legacies/assetManagement/RegularDepositWithDrawalContainer/detailPage/DetailSetting/SwipeableDetailCard.tsx
+++ b/src/legacies/assetManagement/RegularDepositWithDrawalContainer/detailPage/DetailSetting/SwipeableDetailCard.tsx
@@ -33,20 +33,20 @@ function SwipeableDetailCard({ data }: SwipeableDetailCardProps) {
   // };
 
   const deleteData = () => {
-    data.map((d) => {
-      handleDeleteSchedule(d.id as string);
-      closeAlertModal();
-    });
+    // data.map((d) => {
+    //   handleDeleteSchedule(d.id as string);
+    //   closeAlertModal();
+    // });
   };
 
   const modifyData = (form: Schedule) => {
-    data.map((d) => {
-      if (moment().isBefore(d.start_date)) {
-        handleModifySchedule(form);
-      } else {
-        handleModifySchedule(form);
-      }
-    });
+    // data.map((d) => {
+    //   if (moment().isBefore(d.start_date)) {
+    //     handleModifySchedule(form);
+    //   } else {
+    //     handleModifySchedule(form);
+    //   }
+    // });
   };
 
   return (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,7 @@ const queryClient = new QueryClient();
 const ReactQueryDevtoolsProduction = React.lazy(() =>
   import("@tanstack/react-query-devtools/production").then((d) => ({
     default: d.ReactQueryDevtools,
-  })),
+  }))
 );
 
 async function main() {
@@ -34,7 +34,7 @@ async function main() {
   // msw 세팅 끝
 
   const root = ReactDOM.createRoot(
-    document.getElementById("root") as HTMLElement,
+    document.getElementById("root") as HTMLElement
   );
   const persistor = persistStore(store);
 
@@ -52,7 +52,7 @@ async function main() {
         </Provider>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
-    </React.StrictMode>,
+    </React.StrictMode>
   );
 }
 


### PR DESCRIPTION
api 연동을 작업했습니다.

api연결을 하는 과정에서 발생한 문제를 다음과 같습니다.
1. repeat/delete 옵션 선택에 관한 오류
    - nowFromAfter : 선택된 현재 일정부터 이후까지 => 잘 동작됨
    - exceptNowAfter : 현재 일정 제외하고 이후 => 일정이 새로 생김
    - all : 모든 일정 => 에러 (수정, 삭제 모두 안됨)

2. 반복이 아닌 단일 일정은 수정x

3. repeat가 null로 넘어옴

4. period 관련해서 계속 반복과 일정 반복 횟수, 종료 날짜 중 어떤 것을 선택했는지 명확히 이해가 잘 되지 않음

close #211