### PR TITLE
fix: Mixed Content 에러 해결을 위한 meta 태그 header에 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 
 <head>
     <meta charset="UTF-8"/>
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+    
     <!--    <link href="/src/assets/logos/new_logo.png" rel="icon" type="image/svg+xml"/>-->
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta name="apple-mobile-web-app-title" content="FinThePen"/>


### PR DESCRIPTION
[참고 자료](https://stackoverflow.com/questions/35178135/how-to-fix-insecure-content-was-loaded-over-https-but-requested-an-insecure-re)

close #222