### PR TITLE
refactor: 홈 화면 api 연동

### DIFF
--- a/src/app/tanstack-query/home/useDaySchedules.ts
+++ b/src/app/tanstack-query/home/useDaySchedules.ts
@@ -1,7 +1,7 @@
 import { SESSION_STORAGE_KEY_TOKEN } from "@api/keys.ts";
 import { DOMAIN } from "@api/url.ts";
 import { getSessionStorage } from "@utils/storage.ts";
-import { QUERY_KEY_DAY } from "@constants/queryKeys.ts";
+import { QUERY_KEY_DAY, QUERY_KEY_SCHEDULES } from "@constants/queryKeys.ts";
 import { useQuery } from "@tanstack/react-query";
 import { HomeQuery, DaySchedule } from "@app/types/schedule.ts";
 
@@ -25,7 +25,12 @@ const fetchDaySchedules = async (query: HomeQuery) => {
 
 export const useDaySchedules = (query: HomeQuery) => {
   return useQuery({
-    queryKey: [QUERY_KEY_DAY, query.calendar_date],
+    queryKey: [
+      QUERY_KEY_SCHEDULES,
+      query.main_month,
+      QUERY_KEY_DAY,
+      query.calendar_date,
+    ],
     queryFn: () => fetchDaySchedules(query),
   });
 };

--- a/src/app/tanstack-query/home/useMonthSchedules.ts
+++ b/src/app/tanstack-query/home/useMonthSchedules.ts
@@ -1,7 +1,7 @@
 import { SESSION_STORAGE_KEY_TOKEN } from "@api/keys.ts";
 import { DOMAIN } from "@api/url.ts";
 import { getSessionStorage } from "@utils/storage.ts";
-import { QUERY_KEY_MONTH } from "@constants/queryKeys.ts";
+import { QUERY_KEY_MONTH, QUERY_KEY_SCHEDULES } from "@constants/queryKeys.ts";
 import { useQuery } from "@tanstack/react-query";
 import { HomeQuery, MonthSchedule } from "@app/types/schedule.ts";
 
@@ -25,7 +25,7 @@ const fetchMonthSchedules = async (query: HomeQuery) => {
 
 export const useMonthSchedules = (query: HomeQuery) => {
   return useQuery({
-    queryKey: [QUERY_KEY_MONTH, query.main_month],
+    queryKey: [QUERY_KEY_SCHEDULES, query.main_month, QUERY_KEY_MONTH],
     queryFn: () => fetchMonthSchedules(query),
   });
 };

--- a/src/app/tanstack-query/home/useMonthSchedules.ts
+++ b/src/app/tanstack-query/home/useMonthSchedules.ts
@@ -25,7 +25,7 @@ const fetchMonthSchedules = async (query: HomeQuery) => {
 
 export const useMonthSchedules = (query: HomeQuery) => {
   return useQuery({
-    queryKey: [QUERY_KEY_MONTH, query.calendar_date],
+    queryKey: [QUERY_KEY_MONTH, query.main_month],
     queryFn: () => fetchMonthSchedules(query),
   });
 };

--- a/src/app/tanstack-query/home/useWeekSchedules.ts
+++ b/src/app/tanstack-query/home/useWeekSchedules.ts
@@ -40,21 +40,24 @@ const init_data = (date: string) => {
   const format = "M/D";
   const lastDay = moment(`${date}-01`).endOf("month").format("YYYY-MM-DD");
   let count = 1;
-  const result: { [key: string]: WeeklySchedule } = {};
+  let result: WeeklySchedule[] = [];
 
   while (!selected.isSameOrAfter(lastDay, "date")) {
     const first = selected.day(1).format(format);
     const last = selected.day(7).format(format);
-    result[count.toString()] = {
-      week_of_number: `${count}주차`,
-      period: `${first}~${last}`,
-      plus: 0,
-      minus: 0,
-    };
+    result = [
+      ...result,
+      {
+        week_of_number: `${count}주차`,
+        period: `${first}~${last}`,
+        plus: 0,
+        minus: 0,
+      },
+    ];
     count += 1;
   }
   return {
-    ...result,
+    week_schedule: result,
     income: "0",
     available: "0",
     expense: "0",

--- a/src/app/tanstack-query/home/useWeekSchedules.ts
+++ b/src/app/tanstack-query/home/useWeekSchedules.ts
@@ -1,7 +1,7 @@
 import { SESSION_STORAGE_KEY_TOKEN } from "@api/keys.ts";
 import { DOMAIN } from "@api/url.ts";
 import { getSessionStorage } from "@utils/storage.ts";
-import { QUERY_KEY_WEEK } from "@constants/queryKeys.ts";
+import { QUERY_KEY_SCHEDULES, QUERY_KEY_WEEK } from "@constants/queryKeys.ts";
 import { useQuery } from "@tanstack/react-query";
 import {
   HomeQuery,
@@ -30,7 +30,7 @@ const fetchWeekSchedules = async (query: HomeQuery) => {
 
 export const useWeekSchedules = (query: HomeQuery) => {
   return useQuery({
-    queryKey: [QUERY_KEY_WEEK, query.main_month],
+    queryKey: [QUERY_KEY_SCHEDULES, query.main_month, QUERY_KEY_WEEK],
     queryFn: () => fetchWeekSchedules(query),
   });
 };

--- a/src/app/tanstack-query/home/useWeekSchedules.ts
+++ b/src/app/tanstack-query/home/useWeekSchedules.ts
@@ -4,7 +4,6 @@ import { getSessionStorage } from "@utils/storage.ts";
 import { QUERY_KEY_WEEK } from "@constants/queryKeys.ts";
 import { useQuery } from "@tanstack/react-query";
 import {
-  DailySchedule,
   HomeQuery,
   WeeklySchedule,
   WeekSchedule,

--- a/src/app/tanstack-query/schedules/useSchedules.ts
+++ b/src/app/tanstack-query/schedules/useSchedules.ts
@@ -3,11 +3,7 @@ import { DOMAIN } from "@api/url";
 import { getSessionStorage } from "@app/utils/storage";
 import { QUERY_KEY_SCHEDULES } from "@constants/queryKeys";
 import { useQuery } from "@tanstack/react-query";
-import {
-  MonthScheduleQuery,
-  Schedule,
-  ScheduleResponse,
-} from "@app/types/schedule.ts";
+import { MonthScheduleQuery, ScheduleResponse } from "@app/types/schedule.ts";
 
 const fetchMonthSchedules = async (query: MonthScheduleQuery) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");

--- a/src/app/tanstack-query/schedules/useSchedules.ts
+++ b/src/app/tanstack-query/schedules/useSchedules.ts
@@ -3,7 +3,11 @@ import { DOMAIN } from "@api/url";
 import { getSessionStorage } from "@app/utils/storage";
 import { QUERY_KEY_SCHEDULES } from "@constants/queryKeys";
 import { useQuery } from "@tanstack/react-query";
-import { MonthScheduleQuery, Schedule } from "@app/types/schedule.ts";
+import {
+  MonthScheduleQuery,
+  Schedule,
+  ScheduleResponse,
+} from "@app/types/schedule.ts";
 
 const fetchMonthSchedules = async (query: MonthScheduleQuery) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
@@ -15,12 +19,16 @@ const fetchMonthSchedules = async (query: MonthScheduleQuery) => {
       Authorization: "Bearer " + token,
     },
     body: JSON.stringify(query),
-  }).then<Schedule[]>(async (res) => {
+  }).then<ScheduleResponse>(async (res) => {
     if (!res.ok) {
-      return [];
+      return {
+        count: 0,
+        data: [],
+        deposit: 0,
+        withdraw: 0,
+      };
     }
-    const response = await res.json();
-    return response.data === undefined ? [] : response.data;
+    return res.json();
   });
 };
 

--- a/src/app/tanstack-query/schedules/useSchedules.ts
+++ b/src/app/tanstack-query/schedules/useSchedules.ts
@@ -16,6 +16,9 @@ const fetchMonthSchedules = async (query: MonthScheduleQuery) => {
     },
     body: JSON.stringify(query),
   }).then<Schedule[]>(async (res) => {
+    if (!res.ok) {
+      return [];
+    }
     const response = await res.json();
     return response.data === undefined ? [] : response.data;
   });

--- a/src/app/types/schedule.ts
+++ b/src/app/types/schedule.ts
@@ -99,6 +99,13 @@ export interface TodaySchedule extends Omit<Schedule, "schedule_id"> {
   id: string;
 }
 
+export interface ScheduleResponse {
+  count: number;
+  data: Schedule[];
+  deposit: number;
+  withdraw: number;
+}
+
 export interface MonthSchedule {
   income: string;
   available: string;
@@ -124,9 +131,7 @@ export interface WeeklySchedule {
   minus: number;
 }
 
-export type DaySchedule = {
-  [key: string]: DailySchedule;
-} & {
+export interface DaySchedule {
   // 하루동안의 전체 수입
   income: string;
   // 지출 예정
@@ -137,15 +142,4 @@ export type DaySchedule = {
   schedule_count: number;
   // 사용가능 금액 = 지출 목표액 - 지출 - 지출예정
   available?: string | number;
-};
-
-export interface DailySchedule {
-  // 등록된 일정의 이름
-  event_name: string;
-  // 일정의 시작 시간
-  start_time: string;
-  // 일정의 종료 시간
-  end_time: string;
-  // 설정된 금액 (수입 -> + / 지출 -> -)
-  amount: string;
 }

--- a/src/app/types/schedule.ts
+++ b/src/app/types/schedule.ts
@@ -106,13 +106,12 @@ export interface MonthSchedule {
   expense: string;
 }
 
-export type WeekSchedule = {
-  [key: string]: WeeklySchedule;
-} & {
+export interface WeekSchedule {
   income: string;
   available: string;
   expense: string;
-};
+  week_schedule: WeeklySchedule[];
+}
 
 export interface WeeklySchedule {
   // 몇번째 주차인지

--- a/src/components/ScheduleList/ScheduleCard/ScheduleCard.tsx
+++ b/src/components/ScheduleList/ScheduleCard/ScheduleCard.tsx
@@ -45,7 +45,7 @@ function ScheduleCard({
       >
         <Stack direction="row" alignItems="center" spacing={0.5}>
           <Typography fontSize="13px" fontWeight={500}>
-            {schedule.start_date}-{schedule.end_date}
+            {schedule.start_time}-{schedule.end_time}
           </Typography>
           {isRepeat && <RepeatRoundedIcon color="success" fontSize="small" />}
         </Stack>

--- a/src/components/ScheduleList/ScheduleCard/ScheduleCard.tsx
+++ b/src/components/ScheduleList/ScheduleCard/ScheduleCard.tsx
@@ -28,6 +28,7 @@ function ScheduleCard({
       alignItems="center"
       spacing={1.5}
       p={2}
+      sx={{ borderBottom: "1px solid #F7F7F8" }}
       onClick={onClick}
     >
       {icon && (

--- a/src/components/ScheduleList/ScheduleDateBox/ScheduleDateBox.tsx
+++ b/src/components/ScheduleList/ScheduleDateBox/ScheduleDateBox.tsx
@@ -1,15 +1,22 @@
-import { Box, Stack, Typography } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
 import moment from "moment";
 import TodayBadge from "@components/common/TodayBadge";
 
 export interface ConsumptionHeaderProps {
   date: string;
+  count?: number;
 }
 
-function ScheduleDateBox({ date }: ConsumptionHeaderProps) {
+function ScheduleDateBox({ date, count }: ConsumptionHeaderProps) {
   return (
     <Stack direction="row" spacing={1} alignItems="center" px={2.5} py={2}>
       <Typography variant="h2">{moment(date).format("M월 D일")}</Typography>
+
+      {count && (
+        <Typography variant="h4" color="#8C919C">
+          {count}건
+        </Typography>
+      )}
 
       {moment().isSame(date, "day") && <TodayBadge />}
     </Stack>

--- a/src/components/ScheduleList/ScheduleDateBox/ScheduleDateBoxSkeleton.tsx
+++ b/src/components/ScheduleList/ScheduleDateBox/ScheduleDateBoxSkeleton.tsx
@@ -1,0 +1,23 @@
+import { Skeleton, Stack, Typography } from "@mui/material";
+import moment from "moment/moment";
+import { ConsumptionHeaderProps } from "@components/ScheduleList/ScheduleDateBox/ScheduleDateBox.tsx";
+
+function ScheduleDateBoxSkeleton({ date, count }: ConsumptionHeaderProps) {
+  return (
+    <Stack direction="row" spacing={1} alignItems="center" px={2.5} py={2}>
+      <Typography variant="h2">
+        <Skeleton width="50px" />
+      </Typography>
+
+      {count && (
+        <Typography variant="h4" color="#8C919C">
+          <Skeleton width="50px" />
+        </Typography>
+      )}
+
+      {moment().isSame(date, "day") && <Skeleton width="50px" />}
+    </Stack>
+  );
+}
+
+export default ScheduleDateBoxSkeleton;

--- a/src/components/ScheduleList/ScheduleList.tsx
+++ b/src/components/ScheduleList/ScheduleList.tsx
@@ -6,11 +6,14 @@ import { selectIsBudgetHidden } from "@redux/slices/settingSlice.ts";
 import { SCHEDULE_REQUEST } from "@constants/schedule.ts";
 import { useScheduleDrawer } from "@hooks/useScheduleDrawer.tsx";
 import ScheduleDateBox from "components/ScheduleList/ScheduleDateBox";
+import ScheduleCardSkeleton from "@components/ScheduleList/ScheduleCard/ScheduleCardSkeleton.tsx";
+import ScheduleDateBoxSkeleton from "@components/ScheduleList/ScheduleDateBox/ScheduleDateBoxSkeleton.tsx";
 
 interface ScheduleListProps {
   showHeader?: boolean;
   date: string;
   todaySchedules: TodaySchedule[] | Schedule[];
+  isPending: boolean;
   isError: boolean;
   count?: number;
 }
@@ -19,11 +22,34 @@ function ScheduleList({
   showHeader,
   date,
   todaySchedules,
+  isPending,
   isError,
   count,
 }: ScheduleListProps) {
   const isHideBudgetMode = useAppSelector(selectIsBudgetHidden);
   const { openScheduleDrawer } = useScheduleDrawer();
+
+  if (isPending) {
+    return (
+      <>
+        {showHeader && <ScheduleDateBoxSkeleton count={0} date={date} />}
+        {Array.from({ length: 6 }, () => 0).map(() => (
+          <ScheduleCardSkeleton />
+        ))}
+      </>
+    );
+  }
+
+  if (showHeader && todaySchedules.length === 0) {
+    return (
+      <>
+        <ScheduleDateBoxSkeleton count={0} date={date} />
+        {Array.from({ length: 2 }, () => 0).map(() => (
+          <ScheduleCardSkeleton />
+        ))}
+      </>
+    );
+  }
 
   if (todaySchedules.length === 0 || isError) {
     return (

--- a/src/components/ScheduleList/ScheduleList.tsx
+++ b/src/components/ScheduleList/ScheduleList.tsx
@@ -12,6 +12,7 @@ interface ScheduleListProps {
   date: string;
   todaySchedules: TodaySchedule[] | Schedule[];
   isError: boolean;
+  count?: number;
 }
 
 function ScheduleList({
@@ -19,6 +20,7 @@ function ScheduleList({
   date,
   todaySchedules,
   isError,
+  count,
 }: ScheduleListProps) {
   const isHideBudgetMode = useAppSelector(selectIsBudgetHidden);
   const { openScheduleDrawer } = useScheduleDrawer();
@@ -50,7 +52,7 @@ function ScheduleList({
 
   return (
     <>
-      {showHeader && <ScheduleDateBox date={date} />}
+      {showHeader && <ScheduleDateBox count={count} date={date} />}
       {todaySchedules.map((s) => (
         <ScheduleCard
           schedule={s}

--- a/src/components/ScheduleList/ScheduleListHeader/ScheduleListHeader.tsx
+++ b/src/components/ScheduleList/ScheduleListHeader/ScheduleListHeader.tsx
@@ -22,9 +22,9 @@ function ScheduleListHeader({
       alignItems="center"
       py={1}
       px={2.5}
-      // sx={{ backgroundColor: "#FFF", zIndex: 1000 }}
+      sx={{ height: "38px" }}
     >
-      <Typography>
+      <Typography fontSize="13px">
         총&nbsp;<span style={{ color: "#735BF2" }}>{count}</span>건
       </Typography>
       <SelectMenus

--- a/src/components/ScheduleList/ScheduleListHeader/ScheduleListHeader.tsx
+++ b/src/components/ScheduleList/ScheduleListHeader/ScheduleListHeader.tsx
@@ -22,6 +22,7 @@ function ScheduleListHeader({
       alignItems="center"
       py={1}
       px={2.5}
+      // sx={{ backgroundColor: "#FFF", zIndex: 1000 }}
     >
       <Typography>
         총&nbsp;<span style={{ color: "#735BF2" }}>{count}</span>건

--- a/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
+++ b/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
@@ -27,7 +27,7 @@ function ScheduleListPageHeader({
 }: ScheduleListPageHeaderProps) {
   const navigate = useNavigate();
   return (
-    <Box bgcolor="#735bf2" sx={{ position: "sticky", top: 0, zIndex: 100 }}>
+    <Box bgcolor="#735bf2" sx={{ position: "sticky", top: 0, zIndex: 1000 }}>
       <HeaderBox>
         <Stack
           direction="row"

--- a/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
+++ b/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
@@ -5,6 +5,7 @@ import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
 import { useNavigate } from "react-router-dom";
 import SelectYearMonth from "@components/common/SelectYearMonth";
 import { HeaderBox } from "./ScheduleListPageHeader.styles.ts";
+import FilterButton from "@components/layouts/common/TopBar/buttons/FilterButton";
 
 export interface ScheduleListPageHeaderProps {
   date: string;
@@ -49,6 +50,7 @@ function ScheduleListPageHeader({
           spacing={1}
           justifyContent="space-between"
           alignItems="center"
+          sx={{ color: "#FFF" }}
         >
           <SelectYearMonth
             date={date}
@@ -57,6 +59,7 @@ function ScheduleListPageHeader({
             changeYearAndMonth={changeMonth}
           />
           <TuneRoundedIcon onClick={handleClickFilter} />
+          {/*<FilterButton />*/}
         </Stack>
       </HeaderBox>
     </Box>

--- a/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
+++ b/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
@@ -27,7 +27,7 @@ function ScheduleListPageHeader({
 }: ScheduleListPageHeaderProps) {
   const navigate = useNavigate();
   return (
-    <Box bgcolor="#735bf2">
+    <Box bgcolor="#735bf2" sx={{ position: "sticky", top: 0, zIndex: 100 }}>
       <HeaderBox>
         <Stack
           direction="row"

--- a/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
+++ b/src/components/ScheduleList/ScheduleListPageHeader/ScheduleListPageHeader.tsx
@@ -5,7 +5,6 @@ import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
 import { useNavigate } from "react-router-dom";
 import SelectYearMonth from "@components/common/SelectYearMonth";
 import { HeaderBox } from "./ScheduleListPageHeader.styles.ts";
-import FilterButton from "@components/layouts/common/TopBar/buttons/FilterButton";
 
 export interface ScheduleListPageHeaderProps {
   date: string;

--- a/src/components/ScheduleList/ScheduleListSkeleton.tsx
+++ b/src/components/ScheduleList/ScheduleListSkeleton.tsx
@@ -3,7 +3,7 @@ import ScheduleCardSkeleton from "@components/ScheduleList/ScheduleCard/Schedule
 function ScheduleListSkeleton() {
   return Array(3)
     .fill(0)
-    .map(() => <ScheduleCardSkeleton />);
+    .map((_, index) => <ScheduleCardSkeleton key={index} />);
 }
 
 export default ScheduleListSkeleton;

--- a/src/components/common/RoundedButton.tsx
+++ b/src/components/common/RoundedButton.tsx
@@ -17,7 +17,7 @@ function RoundedButton({ children, onClick, value }: RoundedButtonProps) {
         color: "primary.main",
         borderRadius: 30,
         borderWidth: 0,
-        padding: "8px",
+        padding: "0px",
       }}
       onClick={onClick}
     >

--- a/src/components/common/SelectMenus/SelectMenus.tsx
+++ b/src/components/common/SelectMenus/SelectMenus.tsx
@@ -94,6 +94,8 @@ export default function SelectMenus({
           fontSize: "13px",
           color: "#131416",
           fontWeight: 500,
+          padding: 0,
+          height: "22px",
         }}
       >
         {selectedOption}

--- a/src/components/layouts/common/BottomBar.tsx
+++ b/src/components/layouts/common/BottomBar.tsx
@@ -30,7 +30,7 @@ function BottomBar() {
     <BottomNavigation
       showLabels
       value={bottomTabMenu}
-      onChange={(event: React.SyntheticEvent, newValue: any) => {
+      onChange={(event: React.SyntheticEvent, newValue: number) => {
         dispatch(setBottomDrawerTabMenu(newValue));
       }}
       sx={{

--- a/src/components/layouts/common/BottomBar.tsx
+++ b/src/components/layouts/common/BottomBar.tsx
@@ -7,11 +7,7 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import PaidIcon from "@mui/icons-material/Paid";
 import moment from "moment";
 import { INIT_SCHEDULE } from "@constants/schedule.ts";
-import {
-  changeViewMode,
-  selectDate,
-  selectScheduleForm,
-} from "@redux/slices/scheduleSlice.tsx";
+import { changeViewMode, selectDate } from "@redux/slices/scheduleSlice.tsx";
 import { useAppDispatch, useAppSelector } from "@redux/hooks.ts";
 import {
   selectBottomBarOpen,
@@ -32,6 +28,7 @@ function BottomBar() {
 
   return (
     <BottomNavigation
+      showLabels
       value={bottomTabMenu}
       onChange={(event: React.SyntheticEvent, newValue: any) => {
         dispatch(setBottomDrawerTabMenu(newValue));
@@ -41,9 +38,13 @@ function BottomBar() {
         bottom: 0,
         left: 0,
         right: 0,
-        py: 2,
+        pt: 1.5,
+        pb: "22px",
+        px: 4,
         zIndex: 10,
         display: bottomBarOpen ? "flex" : "none",
+        backgroundColor: "#FFF",
+        height: "auto",
       }}
     >
       <BottomNavigationAction
@@ -61,7 +62,9 @@ function BottomBar() {
       />
       <BottomNavigationAction
         label=""
-        icon={<AddCircleIcon />}
+        icon={
+          <AddCircleIcon sx={{ fontSize: "48px", color: "primary.main" }} />
+        }
         onClick={() =>
           openScheduleDrawer(INIT_SCHEDULE(moment(date).format("YYYY-MM-DD")))
         }

--- a/src/components/layouts/common/TopBar/buttons/BackButton.tsx
+++ b/src/components/layouts/common/TopBar/buttons/BackButton.tsx
@@ -1,6 +1,7 @@
 import RoundedButton from "@components/common/RoundedButton.tsx";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import { useNavigate } from "react-router-dom";
+import ClearIcon from "@mui/icons-material/Clear";
 
 interface BackButtonProps {
   handleClick?: () => void;

--- a/src/components/layouts/common/TopBar/buttons/BackButton.tsx
+++ b/src/components/layouts/common/TopBar/buttons/BackButton.tsx
@@ -1,7 +1,6 @@
 import RoundedButton from "@components/common/RoundedButton.tsx";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import { useNavigate } from "react-router-dom";
-import ClearIcon from "@mui/icons-material/Clear";
 
 interface BackButtonProps {
   handleClick?: () => void;

--- a/src/components/layouts/common/TopBar/buttons/FilterButton/FilterButton.tsx
+++ b/src/components/layouts/common/TopBar/buttons/FilterButton/FilterButton.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
-import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import RoundedButton from "../../../../../common/RoundedButton.tsx";
 import FilterDrawer from "@components/layouts/common/TopBar/buttons/FilterButton/FilterDrawer.tsx";
+import TuneRoundedIcon from "@mui/icons-material/TuneRounded";
 
 function FilterButton() {
   const [bottomDrawerOpen, setBottomDrawerOpen] = useState(false);
@@ -9,7 +9,7 @@ function FilterButton() {
   return (
     <>
       <RoundedButton value="user" onClick={() => setBottomDrawerOpen(true)}>
-        <FilterAltIcon />
+        <TuneRoundedIcon />
       </RoundedButton>
       <FilterDrawer
         bottomDrawerOpen={bottomDrawerOpen}

--- a/src/components/layouts/common/TopBar/buttons/LogoButton.tsx
+++ b/src/components/layouts/common/TopBar/buttons/LogoButton.tsx
@@ -11,7 +11,7 @@ function LogoButton() {
   const guestMode = useAppSelector(selectGuestMode);
   return (
     <RoundedButton value="user" onClick={() => navigate(PATH.home)}>
-      <img src={logo} alt="" width="26px" height="26px" />
+      <img src={logo} alt="" width="40px" height="40px" />
       {guestMode && <Typography ml={1}>GUEST MODE</Typography>}
     </RoundedButton>
   );

--- a/src/components/layouts/common/TopBar/headerMode/HomeMode.tsx
+++ b/src/components/layouts/common/TopBar/headerMode/HomeMode.tsx
@@ -13,7 +13,7 @@ function HomeMode() {
       {/* 헤더 좌측 메뉴 */}
       <Stack direction="row" justifyContent="space-between" alignItems="center">
         <LogoButton />
-        <FilterButton />
+        {/*<FilterButton />*/}
       </Stack>
 
       {/* 헤더 중앙 메뉴 */}
@@ -24,7 +24,12 @@ function HomeMode() {
       />
 
       {/* 헤더 우측 메뉴 */}
-      <Stack direction="row" justifyContent="space-between" alignItems="center">
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        spacing={2}
+      >
         <NotificationButton />
         <PersonalButton />
         <SearchButton />

--- a/src/components/layouts/common/TopBar/headerMode/HomeMode.tsx
+++ b/src/components/layouts/common/TopBar/headerMode/HomeMode.tsx
@@ -1,13 +1,10 @@
 import { Stack } from "@mui/material";
-import { useNavigate } from "react-router-dom";
 import LogoButton from "../buttons/LogoButton.tsx";
 import PersonalButton from "../buttons/PersonalButton.tsx";
-import FilterButton from "../buttons/FilterButton";
 import SearchButton from "../buttons/SearchButton";
 import NotificationButton from "../buttons/NotificationButton.tsx";
 
 function HomeMode() {
-  const navigate = useNavigate();
   return (
     <>
       {/* 헤더 좌측 메뉴 */}

--- a/src/components/layouts/common/TopBar/index.tsx
+++ b/src/components/layouts/common/TopBar/index.tsx
@@ -49,12 +49,19 @@ function TopBar() {
   return (
     isHeaderOpen && (
       <>
-        <Box sx={{ position: "relative", height: 70, zIndex: 1000 }}>
+        <Box
+          sx={{
+            position: "sticky",
+            top: 0,
+            backgroundColor: "#FFF",
+            zIndex: 1000,
+          }}
+        >
           <Stack
             direction="row"
             justifyContent="space-between"
-            alignItems="flex-end"
-            sx={{ height: 70, paddingX: "12px" }}
+            alignItems="center"
+            sx={{ paddingX: "20px" }}
           >
             {headerMode === "home" && <HomeMode />}
             {headerMode === "analysis" && <AnalysisMode />}

--- a/src/components/layouts/common/TopNavigationBar/TopNavigationBar.tsx
+++ b/src/components/layouts/common/TopNavigationBar/TopNavigationBar.tsx
@@ -1,6 +1,6 @@
 import { Stack, Typography } from "@mui/material";
 import RoundedButton from "@components/common/RoundedButton.tsx";
-import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
+import ClearIcon from "@mui/icons-material/Clear";
 import * as React from "react";
 
 export interface TopNavigationBarProps {
@@ -12,7 +12,7 @@ function TopNavigationBar({ title, onClick }: TopNavigationBarProps) {
   return (
     <Stack gap={1} direction="row" px="20px" py="12px" alignItems="center">
       <RoundedButton value="arrow-back-ios-icon" onClick={onClick}>
-        <ArrowBackIosIcon />
+        <ClearIcon sx={{ color: "#131416" }} />
       </RoundedButton>
 
       <Typography variant="h4">{title}</Typography>

--- a/src/components/layouts/containerLayout/HomeLayout.tsx
+++ b/src/components/layouts/containerLayout/HomeLayout.tsx
@@ -4,6 +4,8 @@ import { useRef } from "react";
 import { Outlet } from "react-router-dom";
 import BottomBar from "../common/BottomBar.tsx";
 import TopBar from "../common/TopBar";
+import { useAppSelector } from "@redux/hooks.ts";
+import { selectBottomBarOpen } from "@redux/slices/commonSlice.tsx";
 
 // const messageExamples = [
 //   {
@@ -57,6 +59,7 @@ import TopBar from "../common/TopBar";
 
 export default function HomeLayout() {
   const ref = useRef(null);
+  const bottomBarOpen = useAppSelector(selectBottomBarOpen);
   // const [messages, setMessages] = React.useState(() => refreshMessages());
 
   /**
@@ -72,7 +75,7 @@ export default function HomeLayout() {
   // }, [value, setMessages]);
 
   return (
-    <Box sx={{ pb: "82px" }} ref={ref}>
+    <Box sx={{ pb: bottomBarOpen ? "82px" : 0 }} ref={ref}>
       <CssBaseline />
       <TopBar />
       <Box>

--- a/src/components/layouts/containerLayout/HomeLayout.tsx
+++ b/src/components/layouts/containerLayout/HomeLayout.tsx
@@ -72,7 +72,7 @@ export default function HomeLayout() {
   // }, [value, setMessages]);
 
   return (
-    <Box sx={{ pb: 7 }} ref={ref}>
+    <Box sx={{ pb: "82px" }} ref={ref}>
       <CssBaseline />
       <TopBar />
       <Box>

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -65,25 +65,33 @@ function Home() {
 
   return (
     <>
-      <Box my={1} mx={2.5}>
-        {value === 2 ? (
-          <SelectYearMonth
-            date={moment(date).format("YYYY년 M월 D일")}
-            lastMonth={subtractDay}
-            nextMonth={addDay}
-            changeYearAndMonth={pickDay}
-          />
-        ) : (
-          <SelectYearMonth
-            date={moment(date).format("YYYY년 M월")}
-            lastMonth={subtractMonth}
-            nextMonth={addMonth}
-            changeYearAndMonth={pickMonth}
-          />
-        )}
+      <Box
+        sx={{
+          position: "sticky",
+          top: 40,
+          zIndex: 100,
+          backgroundColor: "#FFF",
+        }}
+      >
+        <Box py={1} px={2.5}>
+          {value === 2 ? (
+            <SelectYearMonth
+              date={moment(date).format("YYYY년 M월 D일")}
+              lastMonth={subtractDay}
+              nextMonth={addDay}
+              changeYearAndMonth={pickDay}
+            />
+          ) : (
+            <SelectYearMonth
+              date={moment(date).format("YYYY년 M월")}
+              lastMonth={subtractMonth}
+              nextMonth={addMonth}
+              changeYearAndMonth={pickMonth}
+            />
+          )}
+        </Box>
+        <MenuTab labels={labels} value={value} handleChange={handleChangeTab} />
       </Box>
-
-      <MenuTab labels={labels} value={value} handleChange={handleChangeTab} />
 
       <Swiper
         className="mySwiper"

--- a/src/pages/Home/components/HomeContainer/view/ScheduleList/ScheduleList.tsx
+++ b/src/pages/Home/components/HomeContainer/view/ScheduleList/ScheduleList.tsx
@@ -59,6 +59,7 @@ function ScheduleList() {
     <>
       {todaySchedules.map((schedule, i) => (
         <ScheduleCard
+          key={schedule.schedule_id}
           schedule={schedule}
           category={
             // 추후 제거 예정

--- a/src/pages/Home/components/HomeContainer/view/ScheduleList/ScheduleList.tsx
+++ b/src/pages/Home/components/HomeContainer/view/ScheduleList/ScheduleList.tsx
@@ -1,6 +1,5 @@
 import useSchedule from "@hooks/useSchedule.ts";
 import { Box, CircularProgress, Stack, Typography } from "@mui/material";
-import moment from "moment";
 import ScheduleCard from "./ScheduleCard.tsx";
 import { CATEGORIES, Category } from "@constants/categories.ts";
 import { useState } from "react";
@@ -8,11 +7,7 @@ import { Schedule } from "@app/types/schedule.ts";
 import EasyAuthentication from "@components/sign/EasyAuthentication.tsx";
 import { useAppDispatch } from "@redux/hooks.ts";
 import { changeHideBudgetMode } from "@redux/slices/settingSlice.ts";
-import {
-  INIT_PERIOD,
-  INIT_REPEAT,
-  SCHEDULE_REQUEST,
-} from "@constants/schedule.ts";
+import { SCHEDULE_REQUEST } from "@constants/schedule.ts";
 import { useScheduleDrawer } from "@hooks/useScheduleDrawer.tsx";
 
 function ScheduleList() {
@@ -66,7 +61,6 @@ function ScheduleList() {
             CATEGORIES.find((c) => c.title === schedule.category) ||
             ({ color: "#C8A2C8" } as Category)
           }
-          key={schedule.schedule_id}
           handleModal={handleModal}
           openAuthenticationPage={() => setAuthenticationPageOpen(true)}
         />

--- a/src/pages/Home/pages/DaySchedulePage/DaySchedulePage.tsx
+++ b/src/pages/Home/pages/DaySchedulePage/DaySchedulePage.tsx
@@ -60,6 +60,7 @@ function DaySchedulePage({ updateHeight, navigateTo }: HomePageProps) {
         date={date}
         todaySchedules={todaySchedules}
         isError={isError}
+        isPending={isPending}
       />
     </div>
   );

--- a/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
+++ b/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
@@ -8,7 +8,8 @@ import useMonthSchedule from "@hooks/home/useMonthSchedule.ts";
 import MonthlyBudgetSummarySkeleton from "@pages/Home/next-components/HomeHeader/MonthlyBudgetSummary/MonthlyBudgetSummarySkeleton.tsx";
 import CalendarHeaderSkeleton from "@pages/Home/next-components/ScheduleCalendar/CalendarHeader/CalendarHeaderSkeleton.tsx";
 import ScheduleListSkeleton from "@components/ScheduleList/ScheduleListSkeleton.tsx";
-import { Box } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
+import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import { HomePageProps } from "@pages/Home/Home.tsx";
 import { useEffect } from "react";
 import useSchedule from "@hooks/useSchedule.ts";
@@ -66,9 +67,29 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
 
       <ScheduleList
         date={date}
-        todaySchedules={todaySchedules}
+        todaySchedules={todaySchedules.slice(0, 3)}
         isError={isError}
+        isPending={isPending}
       />
+
+      {todaySchedules.length > 3 && (
+        <Stack
+          p={2}
+          direction="row"
+          justifyContent="center"
+          alignItems="center"
+          spacing={1.5}
+          onClick={navigateTo}
+        >
+          <Typography>
+            <span style={{ color: "#735BF2", fontWeight: 700 }}>
+              {todaySchedules.length - 3}건
+            </span>
+            &nbsp;일정 더보기
+          </Typography>
+          <KeyboardArrowRightIcon sx={{ color: "#8C919C" }} />
+        </Stack>
+      )}
     </Box>
   );
 }

--- a/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
+++ b/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
@@ -11,11 +11,13 @@ import ScheduleListSkeleton from "@components/ScheduleList/ScheduleListSkeleton.
 import { Box } from "@mui/material";
 import { HomePageProps } from "@pages/Home/Home.tsx";
 import { useEffect } from "react";
+import useSchedule from "@hooks/useSchedule.ts";
 
 function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   const { date, monthData, isError, isPending, changeDate } =
     useMonthSchedule();
-  const TodaySchedules = monthData?.today_schedule ?? [];
+  const { todaySchedules } = useSchedule();
+  // const TodaySchedules = monthData?.today_schedule ?? [];
   const showPredict = moment().isSameOrBefore(date, "month");
   const isThisMonth = moment().isSame(date, "month");
 
@@ -53,7 +55,7 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
 
       <CalendarHeader
         date={date}
-        count={TodaySchedules.length}
+        count={todaySchedules.length}
         handleClick={navigateTo}
         isToday={moment().isSame(date, "date")}
       />
@@ -64,7 +66,7 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
 
       <ScheduleList
         date={date}
-        todaySchedules={TodaySchedules}
+        todaySchedules={todaySchedules}
         isError={isError}
       />
     </Box>

--- a/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
+++ b/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
@@ -1,7 +1,7 @@
 import ScheduleListPageHeader from "components/ScheduleList/ScheduleListPageHeader";
 import useHome from "@hooks/useHome.ts";
 import moment from "moment";
-import { Stack } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import SummaryCard from "@pages/Home/next-components/HomeHeader/MonthlyBudgetSummary/SummaryCard";
 import useHeader from "@hooks/useHeader.ts";
 import ScheduleListHeader from "components/ScheduleList/ScheduleListHeader";
@@ -50,12 +50,21 @@ function ScheduleListPage() {
         <SummaryCard title="지출" amount={data?.withdraw ?? 0} />
       </Stack>
 
-      <ScheduleListHeader
-        count={data?.count ?? 0}
-        options={options}
-        selectedOption={selectedOption}
-        setSelectedOption={setSelectedOption}
-      />
+      <Box
+        sx={{
+          position: "sticky",
+          top: 96,
+          backgroundColor: "#FFF",
+          zIndex: 1000,
+        }}
+      >
+        <ScheduleListHeader
+          count={data?.count ?? 0}
+          options={options}
+          selectedOption={selectedOption}
+          setSelectedOption={setSelectedOption}
+        />
+      </Box>
 
       {scheduleDates.map((date) => {
         const schedules = monthSchedules[date] ?? [];

--- a/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
+++ b/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
@@ -67,6 +67,7 @@ function ScheduleListPage() {
             showHeader
             date={date}
             todaySchedules={todaySchedules}
+            count={todaySchedules.length}
             isError={isError}
           />
         );

--- a/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
+++ b/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
@@ -107,6 +107,7 @@ function ScheduleListPage() {
               todaySchedules={todaySchedules}
               count={todaySchedules.length}
               isError={isError}
+              isPending={isPending}
             />
           </div>
         );

--- a/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
+++ b/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
@@ -5,15 +5,28 @@ import { Stack } from "@mui/material";
 import SummaryCard from "@pages/Home/next-components/HomeHeader/MonthlyBudgetSummary/SummaryCard";
 import useHeader from "@hooks/useHeader.ts";
 import ScheduleListHeader from "components/ScheduleList/ScheduleListHeader";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import useSchedule from "@hooks/useSchedule.ts";
+import ScheduleList from "@components/ScheduleList";
 
 function ScheduleListPage() {
   useHeader(false);
   const options = ["최신순", "과거순"];
 
   const { date, subtractMonth, addMonth, pickMonth } = useHome();
+  const { data, monthSchedules, isError, isPending } = useSchedule();
 
   const [selectedOption, setSelectedOption] = useState(options[0]);
+  const [scheduleDates, setScheduleDates] = useState<string[]>([]);
+
+  useEffect(() => {
+    const keys = Object.keys(monthSchedules ?? {});
+    if (selectedOption === "최신순") {
+      setScheduleDates(keys);
+    } else {
+      setScheduleDates(keys.reverse());
+    }
+  }, [data, selectedOption]);
 
   return (
     <>
@@ -33,16 +46,31 @@ function ScheduleListPage() {
         bgcolor="primary.main"
         sx={{ color: "#FFF" }}
       >
-        <SummaryCard title="수입" amount={350000} />
-        <SummaryCard title="지출" amount={-35000} />
+        <SummaryCard title="수입" amount={data?.deposit ?? 0} />
+        <SummaryCard title="지출" amount={data?.withdraw ?? 0} />
       </Stack>
 
       <ScheduleListHeader
-        count={0}
+        count={data?.count ?? 0}
         options={options}
         selectedOption={selectedOption}
         setSelectedOption={setSelectedOption}
       />
+
+      {scheduleDates.map((date) => {
+        const schedules = monthSchedules[date] ?? [];
+        const todaySchedules =
+          selectedOption === "과거순" ? schedules.reverse() : schedules;
+        return (
+          <ScheduleList
+            key={date}
+            showHeader
+            date={date}
+            todaySchedules={todaySchedules}
+            isError={isError}
+          />
+        );
+      })}
     </>
   );
 }

--- a/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
+++ b/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
@@ -5,10 +5,11 @@ import { Box, Stack } from "@mui/material";
 import SummaryCard from "@pages/Home/next-components/HomeHeader/MonthlyBudgetSummary/SummaryCard";
 import useHeader from "@hooks/useHeader.ts";
 import ScheduleListHeader from "components/ScheduleList/ScheduleListHeader";
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import useSchedule from "@hooks/useSchedule.ts";
 import ScheduleList from "@components/ScheduleList";
 import TodayButton from "@pages/Home/pages/DaySchedulePage/components/TodayButton/TodayButton.tsx";
+import FilterDrawer from "@components/layouts/common/TopBar/buttons/FilterButton/FilterDrawer.tsx";
 
 function ScheduleListPage() {
   useHeader(false);
@@ -21,6 +22,7 @@ function ScheduleListPage() {
   const [selectedOption, setSelectedOption] = useState(options[0]);
   const [scheduleDates, setScheduleDates] = useState<string[]>([]);
   const [isVisible, setIsVisible] = useState(false);
+  const [bottomDrawerOpen, setBottomDrawerOpen] = useState(false);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -62,7 +64,7 @@ function ScheduleListPage() {
         date={moment(date).format("YYYY년 M월")}
         addMonth={addMonth}
         subtractMonth={subtractMonth}
-        handleClickFilter={() => alert("filter")}
+        handleClickFilter={() => setBottomDrawerOpen(true)}
         handleClickSearch={() => alert("search")}
         changeMonth={pickMonth}
       />
@@ -114,6 +116,10 @@ function ScheduleListPage() {
       })}
 
       {isVisible && <TodayButton goToday={scrollToToday} />}
+      <FilterDrawer
+        bottomDrawerOpen={bottomDrawerOpen}
+        setBottomDrawerOpen={setBottomDrawerOpen}
+      />
     </>
   );
 }

--- a/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
+++ b/src/pages/Home/pages/ScheduleListPage/ScheduleListPage.tsx
@@ -106,7 +106,7 @@ function ScheduleListPage() {
               date={date}
               todaySchedules={todaySchedules}
               count={todaySchedules.length}
-              isError={isError}
+              isError={!todaySchedules}
               isPending={isPending}
             />
           </div>

--- a/src/pages/Home/pages/WeekSchedulePage/WeekSchedulePage.tsx
+++ b/src/pages/Home/pages/WeekSchedulePage/WeekSchedulePage.tsx
@@ -29,7 +29,7 @@ function WeekSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
         />
         <ThickDivider />
         {weeks.map((w) => (
-          <WeeklyCardSkeleton week={w} />
+          <WeeklyCardSkeleton key={w} week={w} />
         ))}
       </Box>
     );
@@ -49,27 +49,24 @@ function WeekSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
 
       {isThisMonth && <CalendarHeader date={date} handleClick={navigateTo} />}
 
-      {weekData &&
-        weeks.map((w) => {
-          const weeklyData = weekData[w];
-          if (!weeklyData) return;
-          const [start, end] = weeklyData.period.split("~");
-          const isThisWeek =
-            moment().isSameOrAfter(start, "day") &&
-            moment().isSameOrBefore(end, "day");
-          return (
-            <WeeklyCard
-              key={weeklyData.week_of_number}
-              weeklyData={weeklyData}
-              isThisWeek={isThisWeek}
-              navigateTo={
-                !isThisMonth && weeklyData.week_of_number === "1주차"
-                  ? navigateTo
-                  : undefined
-              }
-            />
-          );
-        })}
+      {weekData?.week_schedule.map((schedule) => {
+        const [start, end] = schedule.period.split("~");
+        const isThisWeek =
+          moment().isSameOrAfter(start, "day") &&
+          moment().isSameOrBefore(end, "day");
+        return (
+          <WeeklyCard
+            key={schedule.week_of_number}
+            weeklyData={schedule}
+            isThisWeek={isThisWeek}
+            navigateTo={
+              !isThisMonth && schedule.week_of_number === "1주차"
+                ? navigateTo
+                : undefined
+            }
+          />
+        );
+      })}
     </Box>
   );
 }

--- a/src/pages/Home/pages/WeekSchedulePage/components/WeeklyAmountCard/WeeklyAmountCard.styles.ts
+++ b/src/pages/Home/pages/WeekSchedulePage/components/WeeklyAmountCard/WeeklyAmountCard.styles.ts
@@ -6,7 +6,7 @@ export const AmountBox = styled.div<{ $isTitle?: boolean }>`
   padding: 12px;
 `;
 
-export const AmountText = styled.text`
+export const AmountText = styled.div`
   height: 24px;
   font-size: 16px;
   font-weight: 500;

--- a/src/pages/reports/Report/components/PredictReport/EmptyPredictReport.tsx
+++ b/src/pages/reports/Report/components/PredictReport/EmptyPredictReport.tsx
@@ -22,6 +22,7 @@ function EmptyPredictReport({ month }: EmptyPredictReportProps) {
       <Stack>
         {REPORTTYPE.map((type) => (
           <EmptyPredictReportCard
+            key={type.type}
             month={month}
             type={type}
             selected={selected === type.type}

--- a/src/pages/reports/ReportCategoryDetails/ReportCategoryDetails.tsx
+++ b/src/pages/reports/ReportCategoryDetails/ReportCategoryDetails.tsx
@@ -1,5 +1,5 @@
 import useHeader from "@hooks/useHeader.ts";
-import ScheduleListHeader from "components/ScheduleList/ScheduleListPageHeader";
+import ScheduleListPageHeader from "components/ScheduleList/ScheduleListPageHeader";
 import useCategoryReport from "@hooks/report/useCategoryReport.ts";
 import { useScheduleDrawer } from "@hooks/useScheduleDrawer.tsx";
 import moment from "moment/moment";
@@ -29,7 +29,7 @@ function ReportCategoryDetails() {
 
   return (
     <>
-      <ScheduleListHeader
+      <ScheduleListPageHeader
         date={`${year}년 ${month}월`}
         addMonth={addMonth}
         subtractMonth={subtractMonth}

--- a/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
+++ b/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
@@ -71,14 +71,21 @@ function ReportCategoryBody({
         setSelectedOption={setSelectedOption}
       />
 
-      {scheduleDates.map((date) => (
-        <ScheduleList
-          showHeader
-          date={date}
-          todaySchedules={report?.month_schedule[date] ?? []}
-          isError={!report?.month_schedule[date]}
-        />
-      ))}
+      {scheduleDates.map((date) => {
+        const schedules = report?.month_schedule[date] ?? [];
+        const todaySchedules =
+          selectedOption === "과거순" ? schedules.reverse() : schedules;
+        return (
+          <ScheduleList
+            key={date}
+            showHeader
+            date={date}
+            todaySchedules={todaySchedules}
+            isError={!todaySchedules}
+            isPending={isPending}
+          />
+        );
+      })}
     </>
   );
 }

--- a/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
+++ b/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
@@ -1,5 +1,5 @@
 import { CategoryDetail } from "@app/types/report.ts";
-import { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import ReportEmptyBox from "@pages/reports/ReportMonthDetails/components/ReportEmptyBox";
 import ReportCategorySummary from "@pages/reports/ReportCategoryDetails/components/ReportCategorySummary";
 import ThickDivider from "@components/common/ThickDivider.tsx";
@@ -7,6 +7,8 @@ import ScheduleListHeader from "components/ScheduleList/ScheduleListHeader";
 import ScheduleList from "@components/ScheduleList";
 import ReportCategorySummarySkeleton from "@pages/reports/ReportCategoryDetails/components/ReportCategorySummary/ReportCategorySummarySkeleton.tsx";
 import ScheduleListSkeleton from "@components/ScheduleList/ScheduleListSkeleton.tsx";
+import TodayButton from "@pages/Home/pages/DaySchedulePage/components/TodayButton/TodayButton.tsx";
+import moment from "moment/moment";
 
 export interface ReportCategoryBodyProps {
   report?: CategoryDetail;
@@ -20,9 +22,26 @@ function ReportCategoryBody({
   handleClickAddSchedule,
 }: ReportCategoryBodyProps) {
   const options = ["최신순", "과거순"];
+  // const todayRef = useRef<HTMLDivElement>(null);
 
   const [selectedOption, setSelectedOption] = useState(options[0]);
   const [scheduleDates, setScheduleDates] = useState<string[]>([]);
+  // const [isVisible, setIsVisible] = useState(false);
+  //
+  // useEffect(() => {
+  //   const handleScroll = () => {
+  //     if (todayRef.current) {
+  //       const rect = todayRef.current.getBoundingClientRect();
+  //       setIsVisible(rect.top > window.innerHeight || rect.bottom < 146);
+  //     }
+  //   };
+  //
+  //   window.addEventListener("scroll", handleScroll);
+  //
+  //   return () => {
+  //     window.removeEventListener("scroll", handleScroll);
+  //   };
+  // }, []);
 
   useEffect(() => {
     const keys = Object.keys(report?.month_schedule ?? {});
@@ -31,6 +50,7 @@ function ReportCategoryBody({
     } else {
       setScheduleDates(keys.reverse());
     }
+    // setTimeout(() => scrollToToday(), 10);
   }, [report, selectedOption]);
 
   if (isPending) {
@@ -53,6 +73,15 @@ function ReportCategoryBody({
     return <ReportEmptyBox handleClickAddSchedule={handleClickAddSchedule} />;
   }
 
+  // const scrollToToday = () => {
+  //   if (todayRef.current) {
+  //     todayRef.current.scrollIntoView({
+  //       behavior: "smooth",
+  //       block: "center",
+  //     });
+  //   }
+  // };
+
   return (
     <>
       <ReportCategorySummary
@@ -74,6 +103,7 @@ function ReportCategoryBody({
         const todaySchedules =
           selectedOption === "과거순" ? schedules.reverse() : schedules;
         return (
+          // <div ref={moment().isSame(date, "date") ? todayRef : undefined}>
           <ScheduleList
             key={date}
             showHeader
@@ -82,8 +112,10 @@ function ReportCategoryBody({
             isError={!todaySchedules}
             isPending={isPending}
           />
+          // </div>
         );
       })}
+      {/*{isVisible && <TodayButton goToday={scrollToToday} />}*/}
     </>
   );
 }

--- a/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
+++ b/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
@@ -1,8 +1,6 @@
 import { CategoryDetail } from "@app/types/report.ts";
 import { useEffect, useState } from "react";
 import ReportEmptyBox from "@pages/reports/ReportMonthDetails/components/ReportEmptyBox";
-import moment from "moment";
-import { INIT_SCHEDULE } from "@constants/schedule.ts";
 import ReportCategorySummary from "@pages/reports/ReportCategoryDetails/components/ReportCategorySummary";
 import ThickDivider from "@components/common/ThickDivider.tsx";
 import ScheduleListHeader from "components/ScheduleList/ScheduleListHeader";


### PR DESCRIPTION
홈 화면의 api 연동을 마무리했습니다.

- month, week api 호출을 달이 변동할 때만 호출되도록 수정했습니다.
- 일정 생성, 수정, 삭제될 때 홈 화면의 moth, week, day api도 재호출 되도록 조정했습니다.
- scheduleList에서 일정을 최신순과 과거순으로 정렬하는 기능을 구현했습니다.
- scheduleList에서 오늘의 일정으로 자동 스크롤되는 기능을 추가했습니다.
- 홈 화면의 디자인을 수정했습니다.
  - 헤더의 아이콘 크기, padding 값 수정
  - bottombar의 아이콘 크기, padding 값 수정

close #237