### PR TITLE
refactor: 저축 목표 설정 페이지 디자인 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ### [웹에서 데모버전 확인하기](https://soyoung125.github.io/fin-the-pen-web/)
 
-#### [Storybook](https://645bb0d7fab3ee51343325b9-tedigvught.chromatic.com/)
+### [배포 페이지 바로가기](https://d2vl90cpkqpz2m.cloudfront.net/)
+
+#### [Storybook](https://645bb0d7fab3ee51343325b9-suxfcvqpve.chromatic.com/)
 
 [서버 설치하기](https://github.com/eomheeseung/fin-the-pen)
 
@@ -23,7 +25,7 @@
 - Redux Took Kit
 - TanStack Query (적용중)
 - Material UI
-- Nivo
+- Chart js
 
 - Axios
 - React Router Dom

--- a/src/app/redux/slices/assetSlice.tsx
+++ b/src/app/redux/slices/assetSlice.tsx
@@ -51,6 +51,7 @@ interface InitialState {
     assets: AssetsByCategoryInterface[];
     updateDate: string;
   };
+  assetMenu: number;
 }
 
 const initialState: InitialState = {
@@ -99,6 +100,7 @@ const initialState: InitialState = {
     assets: initAssetsByCategory(),
     updateDate: moment().format("YYYY-MM-DD"),
   },
+  assetMenu: 0,
 };
 
 export const assetSlice = createSlice({
@@ -125,6 +127,9 @@ export const assetSlice = createSlice({
     setSavingDetailSetting: (state, action) => {
       state.savingDetailSetting = action.payload;
     },
+    setAssetMenu: (state, action) => {
+      state.assetMenu = action.payload;
+    },
   },
 });
 export const {
@@ -134,6 +139,7 @@ export const {
   setInitAssetsByCategory,
   setMonthlyConsumptionGoal,
   setSavingDetailSetting,
+  setAssetMenu,
 } = assetSlice.actions;
 
 export const selectSavingGoal = (state: RootState) => state.asset.goal.saving;
@@ -149,5 +155,6 @@ export const selectSavingDetailSetting = (state: RootState) =>
   state.asset.savingDetailSetting;
 export const selectSavingPopUpSetting = (state: RootState) =>
   state.asset.savingDetailSetting.popup;
+export const selectAssetMenu = (state: RootState) => state.asset.assetMenu;
 
 export default assetSlice.reducer;

--- a/src/components/assetManagement/SettingsPaper/SettingCard.tsx
+++ b/src/components/assetManagement/SettingsPaper/SettingCard.tsx
@@ -1,19 +1,20 @@
 import { Box, Stack } from "@mui/material";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
-import { useNavigate } from "react-router-dom";
 import RoundedPaper from "../../common/RoundedPaper";
-import { AssetManagement } from "../../../constants/managements.ts";
+import { AssetManagement } from "@constants/managements.ts";
+import useAsset from "@hooks/assetManagement/useAsset.ts";
 
 interface SettingCardProps {
   setting: AssetManagement;
+  index: number;
 }
 
-function SettingCard({ setting }: SettingCardProps) {
-  const navigate = useNavigate();
+function SettingCard({ setting, index }: SettingCardProps) {
+  const { setMenu } = useAsset();
 
   return (
     <RoundedPaper my={1}>
-      <Box onClick={() => navigate(setting.path)}>
+      <Box onClick={() => setMenu(index)}>
         <Stack direction="row" justifyContent="space-between">
           <Box sx={{ fontWeight: "bold" }}>{setting.title}</Box>
           <KeyboardArrowRightIcon />

--- a/src/components/assetManagement/SettingsPaper/SettingsPaper.tsx
+++ b/src/components/assetManagement/SettingsPaper/SettingsPaper.tsx
@@ -7,8 +7,8 @@ import SettingCard from "./SettingCard";
 function SettingsPaper() {
   return (
     <Stack>
-      {assetManagements.map((s: AssetManagement) => (
-        <SettingCard setting={s} key={s.path} />
+      {assetManagements.map((s: AssetManagement, index) => (
+        <SettingCard setting={s} index={index} key={s.path} />
       ))}
     </Stack>
   );

--- a/src/components/common/RoundedPaper.tsx
+++ b/src/components/common/RoundedPaper.tsx
@@ -1,15 +1,19 @@
-import { Box } from '@mui/material';
-import React from 'react';
+import { Box } from "@mui/material";
+import React from "react";
 
 interface RoundedPaperProps {
   children: React.ReactNode;
   my: number;
 }
+
 function RoundedPaper({ children, my }: RoundedPaperProps) {
   return (
     <Box
       sx={{
-        marginY: my, padding: 2, borderRadius: '8px', boxShadow: '0px 0px 12px 0px rgba(0, 0, 0, 0.15)',
+        marginY: my,
+        padding: "20px",
+        borderRadius: "20px",
+        boxShadow: "0px 0px 12px 0px rgba(0, 0, 0, 0.15)",
       }}
     >
       {children}

--- a/src/components/layouts/common/TopBar/SelectAssetMenu/SelectAssetMenu.tsx
+++ b/src/components/layouts/common/TopBar/SelectAssetMenu/SelectAssetMenu.tsx
@@ -1,6 +1,4 @@
-import { Box, Stack, Typography } from "@mui/material";
 import * as React from "react";
-import { useState } from "react";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import { alpha, styled } from "@mui/material/styles";

--- a/src/components/layouts/common/TopBar/SelectAssetMenu/SelectAssetMenu.tsx
+++ b/src/components/layouts/common/TopBar/SelectAssetMenu/SelectAssetMenu.tsx
@@ -1,0 +1,131 @@
+import { Box, Stack, Typography } from "@mui/material";
+import * as React from "react";
+import { useState } from "react";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import { alpha, styled } from "@mui/material/styles";
+import Menu, { MenuProps } from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import Button from "@mui/material/Button";
+
+export interface SelectAssetMenuProps {
+  selectedOption: number;
+  setSelectedOption: (menu: number) => void;
+  options: string[];
+}
+
+const StyledMenu = styled((props: MenuProps) => (
+  <Menu
+    elevation={0}
+    anchorOrigin={{
+      vertical: "bottom",
+      horizontal: "right",
+    }}
+    transformOrigin={{
+      vertical: "top",
+      horizontal: "right",
+    }}
+    {...props}
+  />
+))(({ theme }) => ({
+  "& .MuiPaper-root": {
+    borderRadius: 6,
+    marginTop: theme.spacing(1),
+    minWidth: 180,
+    color:
+      theme.palette.mode === "light"
+        ? "rgb(55, 65, 81)"
+        : theme.palette.grey[300],
+    boxShadow:
+      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
+    "& .MuiMenu-list": {
+      padding: "0",
+    },
+    "& .MuiMenuItem-root": {
+      "& .MuiSvgIcon-root": {
+        fontSize: 18,
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(1.5),
+      },
+      "&:active": {
+        backgroundColor: alpha(
+          theme.palette.primary.main,
+          theme.palette.action.selectedOpacity
+        ),
+      },
+    },
+  },
+}));
+
+function SelectAssetMenu({
+  selectedOption,
+  options,
+  setSelectedOption,
+}: SelectAssetMenuProps) {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+  const handleSelect = (option: number) => {
+    setSelectedOption(option);
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Button
+        id="demo-customized-button"
+        aria-controls={open ? "demo-customized-menu" : undefined}
+        aria-haspopup="true"
+        aria-expanded={open ? "true" : undefined}
+        variant="text"
+        disableElevation
+        onClick={handleClick}
+        endIcon={
+          open ? (
+            <KeyboardArrowUpIcon sx={{ fontSize: "16px" }} />
+          ) : (
+            <KeyboardArrowDownIcon sx={{ fontSize: "16px" }} />
+          )
+        }
+        sx={{
+          typography: "h2",
+          color: "#131416",
+          padding: 0,
+          height: "22px",
+        }}
+      >
+        {options[selectedOption]}
+      </Button>
+      <StyledMenu
+        id="demo-customized-menu"
+        MenuListProps={{
+          "aria-labelledby": "demo-customized-button",
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+      >
+        {options.map((option, index) => (
+          <MenuItem
+            key={index}
+            onClick={() => handleSelect(index)}
+            disableRipple
+            sx={{
+              background: selectedOption === index ? "#EDEAFF" : "white",
+              fontSize: "13px",
+            }}
+          >
+            {option}
+          </MenuItem>
+        ))}
+      </StyledMenu>
+    </>
+  );
+}
+
+export default SelectAssetMenu;

--- a/src/components/layouts/common/TopBar/SelectAssetMenu/index.ts
+++ b/src/components/layouts/common/TopBar/SelectAssetMenu/index.ts
@@ -1,0 +1,3 @@
+import SelectAssetMenu from "@components/layouts/common/TopBar/SelectAssetMenu/SelectAssetMenu.tsx";
+
+export default SelectAssetMenu;

--- a/src/components/layouts/common/TopBar/headerMode/AssetMode.tsx
+++ b/src/components/layouts/common/TopBar/headerMode/AssetMode.tsx
@@ -1,9 +1,9 @@
 import { Stack } from "@mui/material";
-import LogoButton from "../buttons/LogoButton.tsx";
 import PersonalButton from "../buttons/PersonalButton.tsx";
 import SelectAssetMenu from "@components/layouts/common/TopBar/SelectAssetMenu";
 import useAsset from "@hooks/assetManagement/useAsset.ts";
 import assetManagements from "@constants/managements.ts";
+import BackButton from "@components/layouts/common/TopBar/buttons/BackButton.tsx";
 
 function AssetMode() {
   const { assetMenu, setMenu } = useAsset();
@@ -11,8 +11,7 @@ function AssetMode() {
     <>
       {/* 헤더 좌측 메뉴 */}
       <Stack direction="row" justifyContent="space-between" alignItems="center">
-        {/*<BackButton />*/}
-        <LogoButton />
+        <BackButton />
       </Stack>
 
       {/* 헤더 중앙 메뉴 */}

--- a/src/components/layouts/common/TopBar/headerMode/AssetMode.tsx
+++ b/src/components/layouts/common/TopBar/headerMode/AssetMode.tsx
@@ -1,19 +1,28 @@
 import { Stack } from "@mui/material";
 import LogoButton from "../buttons/LogoButton.tsx";
 import PersonalButton from "../buttons/PersonalButton.tsx";
-import BackButton from "../buttons/BackButton.tsx";
+import SelectAssetMenu from "@components/layouts/common/TopBar/SelectAssetMenu";
+import useAsset from "@hooks/assetManagement/useAsset.ts";
+import assetManagements from "@constants/managements.ts";
 
 function AssetMode() {
+  const { assetMenu, setMenu } = useAsset();
   return (
     <>
       {/* 헤더 좌측 메뉴 */}
       <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <BackButton />
+        {/*<BackButton />*/}
+        <LogoButton />
       </Stack>
 
       {/* 헤더 중앙 메뉴 */}
       <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <LogoButton />
+        {/*<LogoButton />*/}
+        <SelectAssetMenu
+          selectedOption={assetMenu}
+          setSelectedOption={setMenu}
+          options={assetManagements.map((a) => a.title)}
+        />
       </Stack>
 
       {/* 헤더 우측 메뉴 */}

--- a/src/components/layouts/containerLayout/ManagementLayout.tsx
+++ b/src/components/layouts/containerLayout/ManagementLayout.tsx
@@ -1,62 +1,22 @@
-/* eslint-disable max-len */
-import { Box, Typography } from "@mui/material";
-import { Outlet, useLocation, useNavigate } from "react-router-dom";
-import { useEffect, useState } from "react";
-import assetManagements from "../../../constants/managements.ts";
-import SwitchingHeader from "../../common/SwitchingHeader";
+import { Box } from "@mui/material";
+import { Outlet } from "react-router-dom";
 import EasyAuthentication from "@components/sign/EasyAuthentication";
 import useHeader from "@hooks/useHeader.ts";
 import { HEADER_MODE } from "@app/types/common.ts";
-import { useAppDispatch, useAppSelector } from "@redux/hooks.ts";
-import {
-  changeHeaderTitle,
-  selectIsAuthenticated,
-} from "@redux/slices/commonSlice.tsx";
+import { useAppSelector } from "@redux/hooks.ts";
+import { selectIsAuthenticated } from "@redux/slices/commonSlice.tsx";
 
 function ManagementLayout() {
-  const location = useLocation();
-  const navigate = useNavigate();
   const isAuthenticated = useAppSelector(selectIsAuthenticated);
-  const [management, setManagement] = useState(0);
-  const dispatch = useAppDispatch();
 
   useHeader(true, HEADER_MODE.assetManagement);
-
-  useEffect(() => {
-    setManagement(
-      assetManagements.findIndex((s) => s.path === location.pathname)
-    );
-    dispatch(changeHeaderTitle(""));
-  }, []);
-
-  const handleMovement = (type: "+" | "-") => {
-    if (type === "-" && management !== 0) {
-      setManagement(management - 1);
-      navigate(assetManagements[management - 1].path, { replace: true });
-    } else if (type === "+" && management !== 3) {
-      setManagement(management + 1);
-      navigate(assetManagements[management + 1].path, { replace: true });
-    }
-  };
 
   return (
     <>
       <EasyAuthentication />
       {isAuthenticated && (
-        <Box sx={{ pt: 3, px: 2 }}>
-          <SwitchingHeader
-            justifyContent="space-between"
-            handleClickLeftArrow={() => handleMovement("-")}
-            handleClickRightArrow={() => handleMovement("+")}
-          >
-            <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-              {assetManagements[management].title}
-            </Typography>
-          </SwitchingHeader>
-
-          <Box sx={{ my: 3, wordBreak: "keep-all", fontWeight: "bold" }}>
-            <Outlet />
-          </Box>
+        <Box mx={3.5} pt={3} sx={{ wordBreak: "keep-all", fontWeight: "bold" }}>
+          <Outlet />
         </Box>
       )}
     </>

--- a/src/constants/managements.ts
+++ b/src/constants/managements.ts
@@ -14,19 +14,19 @@ const assetManagements: ReadonlyArray<AssetManagement> = [
     path: PATH.savingsGoal,
   },
   {
-    title: "정기 입출금액 설정",
-    color: yellow[200],
-    path: PATH.regularDepositWithdrawal,
+    title: "지출 목표 금액 설정 ",
+    color: teal[200],
+    path: PATH.scheduleManagement,
   },
   {
-    title: "카테고리별 자산 설정",
+    title: "카테고리별 지출액 설정",
     color: lightBlue[200],
     path: PATH.assetsByCategory,
   },
   {
-    title: "일정 관리",
-    color: teal[200],
-    path: PATH.scheduleManagement,
+    title: "정기 입출금액 설정",
+    color: yellow[200],
+    path: PATH.regularDepositWithdrawal,
   },
 ];
 

--- a/src/hooks/assetManagement/useAsset.ts
+++ b/src/hooks/assetManagement/useAsset.ts
@@ -1,0 +1,22 @@
+import { useAppDispatch, useAppSelector } from "@redux/hooks.ts";
+import { selectAssetMenu, setAssetMenu } from "@redux/slices/assetSlice.tsx";
+import assetManagements from "@constants/managements.ts";
+import { useNavigate } from "react-router-dom";
+
+const useAsset = () => {
+  const assetMenu = useAppSelector(selectAssetMenu);
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const setMenu = (menu: number) => {
+    dispatch(setAssetMenu(menu));
+    navigate(assetManagements[menu].path, { replace: true });
+  };
+
+  return {
+    assetMenu,
+    setMenu,
+  };
+};
+
+export default useAsset;

--- a/src/legacies/assetManagement/SavingsGoalContainer/SavingsGoal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/SavingsGoal.tsx
@@ -10,7 +10,7 @@ function SavingsGoal() {
   const { goal, handleSetSavingGoal, handleSetPersonalGoal } = useSavingGoal();
 
   return (
-    <Box mx={3.5} pt={3}>
+    <Box>
       <Stack justifyContent="space-between" spacing="7px">
         <Typography variant="h2">
           <span style={{ fontSize: "20px", color: "#735BF2", fontWeight: 500 }}>

--- a/src/legacies/assetManagement/SavingsGoalContainer/SavingsGoal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/SavingsGoal.tsx
@@ -1,30 +1,31 @@
-import { Box, IconButton, Stack } from "@mui/material";
-import SettingsIcon from "@mui/icons-material/Settings";
-import { useNavigate } from "react-router-dom";
+import { Box, Stack, Typography } from "@mui/material";
 import Saving from "./goals/Saving/Saving.tsx";
 import Personal from "./goals/Personal/Personal.tsx";
-import { PATH } from "@constants/path.ts";
 import { useUser } from "@app/tanstack-query/useUser.ts";
 import useSavingGoal from "@hooks/assetManagement/useSavingGoal.ts";
+import React from "react";
 
 function SavingsGoal() {
   const { data: user } = useUser();
-  const navigate = useNavigate();
   const { goal, handleSetSavingGoal, handleSetPersonalGoal } = useSavingGoal();
 
   return (
-    <>
-      <Stack direction="row" justifyContent="space-between">
-        <Box sx={{ fontWeight: "bold" }}>
-          {`"${user?.name}"님의 한해 저축 목표입니다.`}
-        </Box>
-        <IconButton
-          color="primary"
-          sx={{ p: 0 }}
-          onClick={() => navigate(PATH.savingDetailSetting)}
-        >
-          <SettingsIcon />
-        </IconButton>
+    <Box mx={3.5} pt={3}>
+      <Stack justifyContent="space-between" spacing="7px">
+        <Typography variant="h2">
+          <span style={{ fontSize: "20px", color: "#735BF2", fontWeight: 500 }}>
+            {user?.name}
+          </span>
+          님의 저축 목표 입니다.
+        </Typography>
+
+        <Typography variant="h2">
+          {"오늘까지 총 "}
+          <span style={{ fontSize: "20px", color: "#735BF2", fontWeight: 500 }}>
+            900,000
+          </span>
+          {"원을 저축했어요."}
+        </Typography>
       </Stack>
 
       <Saving
@@ -36,7 +37,7 @@ function SavingsGoal() {
         personal={goal?.personal_goal}
         handleSetPersonalGoal={handleSetPersonalGoal}
       />
-    </>
+    </Box>
   );
 }
 

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/InputModal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/InputModal.tsx
@@ -12,7 +12,6 @@ import {
 import ClearIcon from "@mui/icons-material/Clear";
 import { useState } from "react";
 import { SOMETHING_IS_WRONG } from "@constants/messages.tsx";
-import SwitchButton from "../../../../../components/common/SwitchButton";
 import ResetButton from "@components/common/ResetButton";
 import {
   PersonalGoal,
@@ -44,18 +43,8 @@ function InputModal({
     setForm({ ...form, [state.target.id]: state.target.value });
   };
 
-  const divisionByType = (
-    type: "day" | "month",
-    money: number
-  ): number | string => {
-    switch (type) {
-      case "day":
-        return Math.round(money / 365);
-      case "month":
-        return Math.round(money / 12);
-      default:
-        return SOMETHING_IS_WRONG;
-    }
+  const divisionByType = (money: number): number | string => {
+    return Math.round(money / 12);
   };
 
   const handleReset = async () => {
@@ -74,7 +63,9 @@ function InputModal({
     <Stack p={2} spacing={1}>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <ResetButton handleClick={handleReset} />
-        <Typography variant="h6">Personal Goal</Typography>
+        <Typography sx={{ fontWeight: 500, fontSize: "17px" }}>
+          나만의 저축 목표
+        </Typography>
         <IconButton onClick={closeModal}>
           <ClearIcon />
         </IconButton>
@@ -87,7 +78,7 @@ function InputModal({
           <OutlinedInput
             id="personal_goal"
             startAdornment={
-              <InputAdornment position="start">목표</InputAdornment>
+              <InputAdornment position="start">목표명</InputAdornment>
             }
             value={form.personal_goal}
             onChange={changePersonalGoal}
@@ -131,7 +122,7 @@ function InputModal({
           fullWidth
           InputProps={{
             startAdornment: (
-              <InputAdornment position="start">기한</InputAdornment>
+              <InputAdornment position="start">기간</InputAdornment>
             ),
           }}
           inputProps={{
@@ -142,100 +133,17 @@ function InputModal({
           size="small"
         />
 
-        {/* 적금 단위 */}
-        <Stack direction="row" spacing={1}>
-          <Button
-            fullWidth
-            variant={form.criteria === "day" ? "contained" : "outlined"}
-            onClick={() =>
-              changePersonalGoal({
-                target: {
-                  id: "criteria",
-                  value: "day",
-                },
-              })
-            }
-          >
-            하루 기준
-          </Button>
-          <Button
-            fullWidth
-            variant={form.criteria === "month" ? "contained" : "outlined"}
-            onClick={() =>
-              changePersonalGoal({
-                target: {
-                  id: "criteria",
-                  value: "month",
-                },
-              })
-            }
-          >
-            한달 기준
-          </Button>
-        </Stack>
-
         {/* 필요 적금 액 */}
         <FormControl fullWidth>
           <OutlinedInput
             startAdornment={
-              <InputAdornment position="start">필요 적금액</InputAdornment>
+              <InputAdornment position="start">한 달 저축액</InputAdornment>
             }
-            value={divisionByType(
-              form.criteria,
-              form.goal_amount
-            ).toLocaleString("ko-KR")}
+            value={divisionByType(form.goal_amount).toLocaleString("ko-KR")}
             size="small"
             inputProps={{
               style: { textAlign: "right" },
             }}
-          />
-        </FormControl>
-
-        {/* 자동 적금 */}
-        <FormControl fullWidth>
-          <OutlinedInput
-            startAdornment={
-              <InputAdornment position="start">적금액 송금 설정</InputAdornment>
-            }
-            endAdornment={
-              <SwitchButton
-                checked={form.is_remittance}
-                handleChange={() =>
-                  changePersonalGoal({
-                    target: {
-                      id: "is_remittance",
-                      value: !form.is_remittance,
-                    },
-                  })
-                }
-              />
-            }
-            size="small"
-            readOnly
-          />
-        </FormControl>
-
-        {/* 팝업 */}
-        <FormControl fullWidth>
-          <OutlinedInput
-            startAdornment={
-              <InputAdornment position="start">팝업창</InputAdornment>
-            }
-            endAdornment={
-              <SwitchButton
-                checked={form.pop_on}
-                handleChange={() =>
-                  changePersonalGoal({
-                    target: {
-                      id: "pop_on",
-                      value: !form.pop_on,
-                    },
-                  })
-                }
-              />
-            }
-            size="small"
-            readOnly
           />
         </FormControl>
       </Stack>
@@ -243,13 +151,9 @@ function InputModal({
         fullWidth
         variant="contained"
         onClick={() => {
-          // dispatch(setPersonalGoal(form));
           handleSetPersonalGoal({
             ...form,
-            required_amount: divisionByType(
-              form.criteria,
-              form.goal_amount
-            ).toString(),
+            required_amount: divisionByType(form.goal_amount).toString(),
             goal_amount: form.goal_amount.toString(),
           });
           closeModal();

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/InputModal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/InputModal.tsx
@@ -27,7 +27,7 @@ interface InputModalProps {
 }
 
 interface ChangePersonalGoal {
-  (state: { target: { id: string; value: string | number | boolean } }): void;
+  (state: { target: { id: string; value: string } }): void;
 }
 
 function InputModal({
@@ -39,6 +39,10 @@ function InputModal({
   const [form, setForm] = useState<PersonalGoalForm>(getPersonalForm(personal));
 
   const changePersonalGoal: ChangePersonalGoal = (state) => {
+    const { id, value } = state.target;
+    if (id === "personal_goal" && value.length > 16) return;
+    if (id === "goal_amount" && Number(value) > 10000000) return;
+
     setForm({ ...form, [state.target.id]: state.target.value });
   };
 
@@ -100,7 +104,7 @@ function InputModal({
               changePersonalGoal({
                 target: {
                   id: e.target.id,
-                  value: +e.target.value.replaceAll(",", ""),
+                  value: e.target.value.replaceAll(",", ""),
                 },
               })
             }

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/InputModal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/InputModal.tsx
@@ -11,7 +11,6 @@ import {
 } from "@mui/material";
 import ClearIcon from "@mui/icons-material/Clear";
 import { useState } from "react";
-import { SOMETHING_IS_WRONG } from "@constants/messages.tsx";
 import ResetButton from "@components/common/ResetButton";
 import {
   PersonalGoal,

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/Personal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/Personal.tsx
@@ -1,11 +1,12 @@
-import { Box, Grid, IconButton, Stack } from "@mui/material";
-import BorderColorIcon from "@mui/icons-material/BorderColor";
-import RoundedBorderBox from "../../../../../components/common/RoundedBorderBox";
+import { Box, IconButton, Stack } from "@mui/material";
 import InputModal from "./InputModal";
 import { PersonalGoal, SetPersonalGoalQuery } from "@app/types/asset.ts";
 import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
 import { useDialog } from "@hooks/dialog/useDialog.tsx";
 import { useModal } from "@hooks/modal/useModal.tsx";
+import RoundedPaper from "@components/common/RoundedPaper.tsx";
+import filter_main from "@assets/icons/header/filter_main.svg";
+import GoalCard from "@legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard";
 
 interface PersonalProps {
   personal?: PersonalGoal;
@@ -38,52 +39,35 @@ function Personal({ personal, handleSetPersonalGoal }: PersonalProps) {
   };
 
   return (
-    <>
-      <Stack direction="row" justifyContent="space-between" alignItems="center">
-        <Box sx={{ fontWeight: "bold" }}>당신의 또 다른 목표는 무엇인가요?</Box>
-        <IconButton color="primary" onClick={handleModify}>
-          <BorderColorIcon fontSize="small" />
-        </IconButton>
-      </Stack>
-      <Grid container spacing={1} textAlign="center" mt={0}>
-        <Grid item xs={6}>
-          <Stack
-            justifyContent="space-around"
-            sx={{
-              borderRadius: 2,
-              backgroundColor: "primary.main",
-              color: "white",
-              p: 2,
-              height: "100%",
-            }}
-          >
-            <Box mb={2}>나의 목표</Box>
-            <Box>{personal?.goal_name}</Box>
-            <Box>{getAmount(personal?.goal_amount)}원</Box>
-          </Stack>
-        </Grid>
+    <Box mt="50px">
+      <RoundedPaper my={2}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Box sx={{ fontSize: "18px", fontWeight: "700" }}>
+            나만의 저축 목표
+          </Box>
+          <IconButton color="primary" onClick={handleModify}>
+            <img src={filter_main} alt="filter" />
+          </IconButton>
+        </Stack>
 
-        <Grid item xs={6}>
-          <RoundedBorderBox>
-            <Stack direction="row" justifyContent="space-between" p={2}>
-              <Box>기간</Box>
-              <Box sx={{ color: "primary.main" }}>{personal?.period}</Box>
-            </Stack>
-          </RoundedBorderBox>
-
-          <Box my={1} />
-
-          <RoundedBorderBox>
-            <Box p={2}>
-              <Box mb={1}>핀더펜 MONEY</Box>
-              <Box sx={{ color: "primary.main" }}>
-                {getAmount(personal?.goal_amount)}원
-              </Box>
-            </Box>
-          </RoundedBorderBox>
-        </Grid>
-      </Grid>
-    </>
+        <Stack direction="row" spacing={4} mt={3.5}>
+          <GoalCard
+            title={personal?.goal_name ?? ""}
+            subTitle={`${personal?.period}까지`}
+            amount={getAmount(personal?.goal_amount) ?? 0}
+          />
+          <GoalCard
+            title="저축 목표액"
+            subTitle="한달 기준"
+            amount={getAmount(personal?.required_amount) ?? 0}
+          />
+        </Stack>
+      </RoundedPaper>
+    </Box>
   );
 }
 

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/GoalCard.styles.ts
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/GoalCard.styles.ts
@@ -1,0 +1,17 @@
+import styled from "@emotion/styled";
+
+export const GoalHeader = styled.div`
+  background-color: #eae1fd;
+  color: #735bf2;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  text-align: center;
+  font-weight: 700;
+`;
+
+export const GoalBody = styled.div`
+  padding-top: 10px;
+  padding-bottom: 18px;
+  padding-left: 3px;
+  border-bottom: 1px solid #6d29f6;
+`;

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/GoalCard.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/GoalCard.tsx
@@ -1,0 +1,36 @@
+import {
+  GoalBody,
+  GoalHeader,
+} from "@legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/GoalCard.styles.ts";
+import { Stack, Typography, Box } from "@mui/material";
+
+export interface GoalCardProps {
+  title: string;
+  subTitle: string;
+  amount: number;
+}
+
+function GoalCard({ title, subTitle, amount }: GoalCardProps) {
+  return (
+    <Stack width="100%">
+      <GoalHeader>{title}</GoalHeader>
+      <GoalBody>
+        <Stack spacing="13px">
+          <Typography variant="subtitle2">{subTitle}</Typography>
+          <Box
+            sx={{
+              textAlign: "center",
+              fontSize: "18px",
+              fontWeight: 700,
+              color: "#735BF2",
+            }}
+          >
+            {amount.toLocaleString()}원
+          </Box>
+        </Stack>
+      </GoalBody>
+    </Stack>
+  );
+}
+
+export default GoalCard;

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/index.ts
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/index.ts
@@ -1,0 +1,3 @@
+import GoalCard from "@legacies/assetManagement/SavingsGoalContainer/goals/Personal/components/GoalCard/GoalCard.tsx";
+
+export default GoalCard;

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/InputModal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/InputModal.tsx
@@ -3,16 +3,13 @@ import {
   Divider,
   FormControl,
   IconButton,
-  InputAdornment,
-  OutlinedInput,
   Stack,
   TextField,
   Typography,
 } from "@mui/material";
 import ClearIcon from "@mui/icons-material/Clear";
-import { useSelector } from "react-redux";
-import { useEffect, useState } from "react";
-import { selectSavingGoal, setSavingGoal } from "@redux/slices/assetSlice.tsx";
+import { useState } from "react";
+import { setSavingGoal } from "@redux/slices/assetSlice.tsx";
 import { useAppDispatch } from "@redux/hooks.ts";
 import ResetButton from "@components/common/ResetButton";
 import { useDialog } from "@hooks/dialog/useDialog.tsx";

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/InputModal.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/InputModal.tsx
@@ -14,7 +14,6 @@ import { useSelector } from "react-redux";
 import { useEffect, useState } from "react";
 import { selectSavingGoal, setSavingGoal } from "@redux/slices/assetSlice.tsx";
 import { useAppDispatch } from "@redux/hooks.ts";
-import SwitchButton from "../../../../../components/common/SwitchButton";
 import ResetButton from "@components/common/ResetButton";
 import { useDialog } from "@hooks/dialog/useDialog.tsx";
 import { SavingGoal } from "@app/types/asset.ts";
@@ -34,8 +33,6 @@ function InputModal({
   const [form, setForm] = useState({
     year: getAmount(saving?.years_goal_amount),
     month: getAmount(saving?.months_goal_amount),
-    autoSaving: true,
-    popUp: false,
   });
   const { openConfirm } = useDialog();
 
@@ -53,22 +50,10 @@ function InputModal({
     }
   };
 
-  const changeSavingGoal = (id: string, value: boolean): void => {
-    setForm({ ...form, [id]: value });
-  };
-
   /**
    * redux에 이미 저장된 목표 값 불러오기
    */
   const dispatch = useAppDispatch();
-  const savingOption = useSelector(selectSavingGoal);
-  useEffect(() => {
-    setForm({
-      ...form,
-      autoSaving: savingOption.autoSaving,
-      popUp: savingOption.popUp,
-    });
-  }, [savingOption]);
 
   const handleReset = async () => {
     const answer = await openConfirm({
@@ -81,17 +66,15 @@ function InputModal({
       setForm({
         year: 0,
         month: 0,
-        autoSaving: true,
-        popUp: false,
       });
     }
   };
 
   return (
-    <Stack p={2} spacing={1}>
+    <Stack p={2} spacing={1} sx={{ minWidth: "320px" }}>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <ResetButton handleClick={handleReset} />
-        <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+        <Typography sx={{ fontWeight: 500, fontSize: "17px" }}>
           저축 목표 설정
         </Typography>
         <IconButton onClick={() => closeSavingGoalModal()}>
@@ -102,14 +85,14 @@ function InputModal({
       <Divider sx={{ marginY: 1 }} />
 
       <Stack spacing={1}>
-        <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-          1 Year Goal
+        <Typography variant="h2" sx={{ fontWeight: "bold" }}>
+          한 해 저축 목표
         </Typography>
         <TextField
           fullWidth
           placeholder="한해동안의 저축 목표액을 입력하세요"
           type="text"
-          value={form.year.toLocaleString("ko-KR")}
+          value={form.year !== 0 ? form.year.toLocaleString("ko-KR") : ""}
           onFocus={(e) => e.target.select()}
           onChange={handleChange}
           id="year"
@@ -117,58 +100,24 @@ function InputModal({
             style: { textAlign: "right" },
           }}
         />
-        <Typography variant="h6" sx={{ fontWeight: "bold" }}>
-          1 Month Goal
+        <Typography variant="h2" sx={{ fontWeight: "bold" }}>
+          월 저축 목표
         </Typography>
-        <TextField
-          fullWidth
-          placeholder="한해 저축 목표액을 입력하면 한달 저축 목표금액이 표시됩니다. "
-          type="text"
-          value={form.month.toLocaleString("ko-KR")}
-          onFocus={(e) => e.target.select()}
-          onChange={handleChange}
-          id="month"
-          inputProps={{
-            style: { textAlign: "right" },
-          }}
-        />
-
-        {/* 적금액 송금 설정 */}
         <FormControl fullWidth>
-          <OutlinedInput
-            startAdornment={
-              <InputAdornment position="start">적금액 송금 설정</InputAdornment>
-            }
-            endAdornment={
-              <SwitchButton
-                checked={form.autoSaving}
-                handleChange={() =>
-                  changeSavingGoal("autoSaving", !form.autoSaving)
-                }
-              />
-            }
-            size="small"
-            readOnly
-          />
-        </FormControl>
-
-        {/* 팝업창 */}
-        <FormControl fullWidth>
-          <OutlinedInput
-            startAdornment={
-              <InputAdornment position="start">팝업창</InputAdornment>
-            }
-            endAdornment={
-              <SwitchButton
-                checked={form.popUp}
-                handleChange={() => changeSavingGoal("popUp", !form.popUp)}
-              />
-            }
-            size="small"
-            readOnly
+          <TextField
+            placeholder="한해 저축 목표액을 입력하면 한달 저축 목표금액이 표시됩니다."
+            type="text"
+            value={form.month !== 0 ? form.month.toLocaleString("ko-KR") : ""}
+            onFocus={(e) => e.target.select()}
+            onChange={handleChange}
+            id="month"
+            inputProps={{
+              style: { textAlign: "right" },
+            }}
           />
         </FormControl>
       </Stack>
+
       <Button
         fullWidth
         variant="contained"
@@ -178,7 +127,7 @@ function InputModal({
           closeSavingGoalModal();
         }}
       >
-        한해 저축 목표 설정하기
+        완료
       </Button>
     </Stack>
   );

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/Saving.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/Saving.tsx
@@ -47,7 +47,9 @@ function Saving({ saving, handleSetSavingGoal }: SavingProps) {
           alignItems="center"
           pb={1}
         >
-          <Box sx={{ fontSize: "18px", fontWeight: "700" }}>1 Year Goal</Box>
+          <Box sx={{ fontSize: "18px", fontWeight: "700" }}>
+            한 해 저축 목표
+          </Box>
           <IconButton color="primary" onClick={handleModify} sx={{ p: 0 }}>
             <img src={filter_main} alt="filter" />
           </IconButton>
@@ -67,7 +69,7 @@ function Saving({ saving, handleSetSavingGoal }: SavingProps) {
         </RoundedBorderBox>
 
         <Box sx={{ fontSize: "18px", fontWeight: "700" }} pb={1} pt={2}>
-          1 Month Goal
+          월 저축 목표
         </Box>
         <RoundedBorderBox>
           <Box

--- a/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/Saving.tsx
+++ b/src/legacies/assetManagement/SavingsGoalContainer/goals/Saving/Saving.tsx
@@ -1,15 +1,12 @@
-import { Box, IconButton, Stack, Typography } from "@mui/material";
-import BorderColorIcon from "@mui/icons-material/BorderColor";
+import { Box, IconButton, Stack } from "@mui/material";
 import RoundedPaper from "../../../../../components/common/RoundedPaper";
-import ModalStaticBackdrop from "../../../../../components/layouts/ModalStaticBackdrop";
 import RoundedBorderBox from "../../../../../components/common/RoundedBorderBox";
 import InputModal from "./InputModal";
-import useModal_deprecated from "@hooks/useModal_deprecated.ts";
 import { SavingGoal } from "@app/types/asset.ts";
 import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
 import { useDialog } from "@hooks/dialog/useDialog.tsx";
 import { useModal } from "@hooks/modal/useModal.tsx";
-import UseableInfoModal from "@pages/reports/Report/components/modals/UseableInfoModal";
+import filter_main from "@assets/icons/header/filter_main.svg";
 
 interface SavingProps {
   saving?: SavingGoal;
@@ -42,7 +39,7 @@ function Saving({ saving, handleSetSavingGoal }: SavingProps) {
   };
 
   return (
-    <>
+    <Box mt="30px">
       <RoundedPaper my={2}>
         <Stack
           direction="row"
@@ -50,9 +47,9 @@ function Saving({ saving, handleSetSavingGoal }: SavingProps) {
           alignItems="center"
           pb={1}
         >
-          <Typography variant="h1">1 Year Goal</Typography>
+          <Box sx={{ fontSize: "18px", fontWeight: "700" }}>1 Year Goal</Box>
           <IconButton color="primary" onClick={handleModify} sx={{ p: 0 }}>
-            <BorderColorIcon fontSize="small" />
+            <img src={filter_main} alt="filter" />
           </IconButton>
         </Stack>
         <RoundedBorderBox>
@@ -69,9 +66,9 @@ function Saving({ saving, handleSetSavingGoal }: SavingProps) {
           </Box>
         </RoundedBorderBox>
 
-        <Typography variant="h1" pb={1} pt={2}>
+        <Box sx={{ fontSize: "18px", fontWeight: "700" }} pb={1} pt={2}>
           1 Month Goal
-        </Typography>
+        </Box>
         <RoundedBorderBox>
           <Box
             sx={{
@@ -86,7 +83,7 @@ function Saving({ saving, handleSetSavingGoal }: SavingProps) {
           </Box>
         </RoundedBorderBox>
       </RoundedPaper>
-    </>
+    </Box>
   );
 }
 

--- a/src/pages/reports/ReportMonthDetails/components/ReportMonthTitle/ReportMonthTitle.stories.tsx
+++ b/src/pages/reports/ReportMonthDetails/components/ReportMonthTitle/ReportMonthTitle.stories.tsx
@@ -13,6 +13,8 @@ const meta = {
     year: 2023,
     month: 5,
     onClickMonth: () => alert("하단의 State 예제를 사용해주세요."),
+    goal: 1000,
+    spent: 1000,
   },
   argTypes: {},
 } satisfies Meta<typeof ReportMonthTitle>;


### PR DESCRIPTION
자산관리의 저축 목표 설정 페이지 디자인을 수정했습니다.

- 자산 관리 세부 설정 페이지 헤더 디자인을 수정했습니다.
  - 세부 설정 페이지 이동을 위한 select menu 컴포넌트를 구현했습니다.
  - 기존의 세부 페이지 이동 컴포넌트를 제거했습니다.
- 저축 목표 설정 페이지의 텍스트를 수정합니다.
- 한 해 저축 목표 설정 모달 디자인 수정
  - 불필요한 입력 제거
- 개인 저축 목표 설정 모달 디자인 수정
  - 불필요한 입력 제거
  - 유효성 검사 진행

close #249