### PR TITLE
feat: 지출 목표 설정 페이지 컴포넌트 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### [배포 페이지 바로가기](https://d2vl90cpkqpz2m.cloudfront.net/)
 
-#### [Storybook](https://645bb0d7fab3ee51343325b9-suxfcvqpve.chromatic.com/)
+#### [Storybook](https://645bb0d7fab3ee51343325b9-xkrvwsgicz.chromatic.com/)
 
 [서버 설치하기](https://github.com/eomheeseung/fin-the-pen)
 

--- a/src/app/routes/MANAGEMENT_ROUTES.tsx
+++ b/src/app/routes/MANAGEMENT_ROUTES.tsx
@@ -3,9 +3,9 @@ import RegularDepositWithdrawal from "../../legacies/assetManagement/RegularDepo
 import DetailInformation from "../../legacies/assetManagement/RegularDepositWithDrawalContainer/detailPage/DetailInformation";
 import DetailSetting from "../../legacies/assetManagement/RegularDepositWithDrawalContainer/detailPage/DetailSetting";
 import SavingsGoal from "../../legacies/assetManagement/SavingsGoalContainer/SavingsGoal.tsx";
-import ScheduleManagement from "../../legacies/assetManagement/ScheduleManagement";
 import { PATH } from "@constants/path.ts";
 import { RouterDOM } from "@app/types/common.ts";
+import SpendingGoal from "@legacies/assetManagement/SpendingGoal";
 
 const MANAGEMENT_ROUTES: RouterDOM[] = [
   {
@@ -30,7 +30,7 @@ const MANAGEMENT_ROUTES: RouterDOM[] = [
   },
   {
     path: PATH.scheduleManagement,
-    element: <ScheduleManagement />,
+    element: <SpendingGoal />,
   },
 ];
 

--- a/src/hooks/date-picker/DatePicker.stories.tsx
+++ b/src/hooks/date-picker/DatePicker.stories.tsx
@@ -10,11 +10,12 @@ export const Example = () => {
     openDayPicker,
     openTimePicker,
     openMonthPeriodPicker,
+    openDayPeriodPicker,
   } = useDatePicker();
   const [value, setValue] = useState("버튼을 눌러 업데이트 해주세요");
   const [period, setPeriod] = useState({
-    start: moment().format("YYYY-MM"),
-    end: moment().format("YYYY-MM"),
+    start: moment().format("YYYY-MM-DD"),
+    end: moment().format("YYYY-MM-DD"),
   });
   const handleMonthPicker = async () => {
     const newDate = await openMonthPicker("2021-10");
@@ -23,7 +24,10 @@ export const Example = () => {
   };
 
   const handleMonthPeriodPicker = async () => {
-    const newDate = await openMonthPeriodPicker(period.start, period.end);
+    const newDate = await openMonthPeriodPicker(
+      moment(period.start).format("YYYY-MM"),
+      moment(period.end).format("YYYY-MM")
+    );
     if (!newDate) return;
     setPeriod(newDate);
   };
@@ -32,6 +36,15 @@ export const Example = () => {
     const newDate = await openDayPicker("2021-10-11");
     if (!newDate) return;
     setValue(newDate);
+  };
+
+  const handleDayPeriodPicker = async () => {
+    const newDate = await openDayPeriodPicker(
+      moment(period.start).format("YYYY-MM-DD"),
+      moment(period.end).format("YYYY-MM-DD")
+    );
+    if (!newDate) return;
+    setPeriod(newDate);
   };
 
   const handleTimePicker = async () => {
@@ -58,7 +71,14 @@ export const Example = () => {
         color="primary"
         onClick={handleMonthPeriodPicker}
       >
-        기간 선택기
+        월 기간 선택기
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleDayPeriodPicker}
+      >
+        일 기간 선택기
       </Button>
     </>
   );

--- a/src/hooks/date-picker/DatePicker.stories.tsx
+++ b/src/hooks/date-picker/DatePicker.stories.tsx
@@ -2,14 +2,30 @@ import { Meta } from "@storybook/react";
 import { useDatePicker } from "./hooks/useDatePicker.tsx";
 import { useState } from "react";
 import { Button, Typography } from "@mui/material";
+import moment from "moment";
 
 export const Example = () => {
-  const { openMonthPicker, openDayPicker, openTimePicker } = useDatePicker();
+  const {
+    openMonthPicker,
+    openDayPicker,
+    openTimePicker,
+    openMonthPeriodPicker,
+  } = useDatePicker();
   const [value, setValue] = useState("버튼을 눌러 업데이트 해주세요");
+  const [period, setPeriod] = useState({
+    start: moment().format("YYYY-MM"),
+    end: moment().format("YYYY-MM"),
+  });
   const handleMonthPicker = async () => {
     const newDate = await openMonthPicker("2021-10");
     if (!newDate) return;
     setValue(newDate.format("YYYY-MM"));
+  };
+
+  const handleMonthPeriodPicker = async () => {
+    const newDate = await openMonthPeriodPicker(period.start, period.end);
+    if (!newDate) return;
+    setPeriod(newDate);
   };
 
   const handleDayPicker = async () => {
@@ -35,6 +51,14 @@ export const Example = () => {
       </Button>
       <Button variant="contained" color="warning" onClick={handleTimePicker}>
         시간 선택기
+      </Button>
+      <Typography>{`PeriodPicker에 의해서 선택된 값 : ${period.start} ~ ${period.end}`}</Typography>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleMonthPeriodPicker}
+      >
+        기간 선택기
       </Button>
     </>
   );

--- a/src/hooks/date-picker/components/DatePeriodPicker.tsx
+++ b/src/hooks/date-picker/components/DatePeriodPicker.tsx
@@ -1,0 +1,145 @@
+import {
+  Box,
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import {
+  DateCalendar,
+  LocalizationProvider,
+  PickersDay,
+  PickersDayProps,
+} from "@mui/x-date-pickers";
+import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
+import { useState } from "react";
+import moment from "moment/moment";
+import Modal from "@hooks/modal/Modal.tsx";
+import "moment/dist/locale/ko";
+
+interface DatePeriodPickerProps {
+  defaultStartDate: string;
+  defaultEndDate: string;
+  onClickApprove: (start: string, end: string) => void;
+  onClickReject: (start: string, end: string) => void;
+}
+
+function DatePeriodPicker({
+  defaultStartDate,
+  defaultEndDate,
+  onClickApprove,
+  onClickReject,
+}: DatePeriodPickerProps) {
+  const [newDate, setNewDate] = useState({
+    startDate: defaultStartDate,
+    endDate: defaultEndDate,
+  });
+  const [isSelectStartDate, setIsSelectStartDate] = useState(true);
+
+  const changeDate = (date: string) => {
+    if (isSelectStartDate) {
+      if (moment(date).isAfter(newDate.endDate)) {
+        changeStartAndEndDate(date);
+      } else {
+        setNewDate({ ...newDate, startDate: date });
+      }
+    } else {
+      if (moment(date).isBefore(newDate.startDate)) {
+        changeStartAndEndDate(date);
+      } else {
+        setNewDate({ ...newDate, endDate: date });
+      }
+    }
+    setIsSelectStartDate((prev) => !prev);
+  };
+
+  const changeStartAndEndDate = (date: string) => {
+    setNewDate({ ...newDate, startDate: date, endDate: date });
+  };
+
+  const handleSetDate = () => {
+    const { startDate, endDate } = newDate;
+    onClickApprove(startDate, endDate);
+  };
+
+  const renderDayInPicker = (props: PickersDayProps<moment.Moment>) => {
+    const { day, ...other } = props;
+    const { startDate, endDate } = newDate;
+    if (moment(startDate).isSame(endDate)) {
+      return <PickersDay {...props} />;
+    }
+    if (moment(startDate).isSame(day)) {
+      return (
+        <PickersDay
+          sx={{
+            borderTopRightRadius: 0,
+            borderBottomRightRadius: 0,
+            marginX: 0,
+            width: "40px",
+          }}
+          className="Mui-selected"
+          {...props}
+        />
+      );
+    }
+    if (moment(endDate).isSame(day)) {
+      return (
+        <PickersDay
+          sx={{
+            borderTopLeftRadius: 0,
+            borderBottomLeftRadius: 0,
+            marginX: 0,
+            width: "40px",
+          }}
+          className="Mui-selected"
+          {...props}
+        />
+      );
+    }
+    if (moment(startDate).isBefore(day) && moment(endDate).isAfter(day)) {
+      return (
+        <PickersDay
+          sx={{
+            borderRadius: 0,
+            marginX: 0,
+            width: "40px",
+          }}
+          className="Mui-selected"
+          {...props}
+        />
+      );
+    }
+    return <PickersDay {...props} />;
+  };
+
+  return (
+    <Modal>
+      <DialogTitle id="alert-dialog-title">날짜 선택</DialogTitle>
+      <DialogContent>
+        <Box>{`시작일: ${newDate.startDate} ~ 종료일: ${newDate.endDate}`}</Box>
+        <LocalizationProvider dateAdapter={AdapterMoment}>
+          <DateCalendar
+            views={["year", "month", "day"]}
+            openTo="day"
+            value={moment(
+              isSelectStartDate ? newDate.startDate : newDate.endDate
+            )}
+            onChange={(newValue) => {
+              newValue && changeDate(newValue.format("YYYY-MM-DD"));
+            }}
+            slots={{
+              day: renderDayInPicker,
+            }}
+          />
+        </LocalizationProvider>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleSetDate} autoFocus>
+          설정
+        </Button>
+      </DialogActions>
+    </Modal>
+  );
+}
+
+export default DatePeriodPicker;

--- a/src/hooks/date-picker/components/MonthPeriodPicker.tsx
+++ b/src/hooks/date-picker/components/MonthPeriodPicker.tsx
@@ -1,0 +1,157 @@
+import {
+  Button,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+import {
+  DateCalendar,
+  LocalizationProvider,
+  PickersDay,
+  PickersDayProps,
+} from "@mui/x-date-pickers";
+import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
+import { useState } from "react";
+import moment from "moment/moment";
+import Modal from "@hooks/modal/Modal.tsx";
+import "moment/dist/locale/ko";
+
+interface MonthPeriodPickerProps {
+  defaultStartDate: string;
+  defaultEndDate: string;
+  onClickApprove: (start: string, end: string) => void;
+  onClickReject: (start: string, end: string) => void;
+}
+
+function MonthPeriodPicker({
+  defaultStartDate,
+  defaultEndDate,
+  onClickApprove,
+  onClickReject,
+}: MonthPeriodPickerProps) {
+  const [newDate, setNewDate] = useState({
+    startDate: defaultStartDate,
+    endDate: defaultEndDate,
+  });
+  const [isSelectStartDate, setIsSelectStartDate] = useState(true);
+
+  const changeDate = (date: string) => {
+    console.log(date);
+    if (isSelectStartDate) {
+      if (moment(date).isAfter(newDate.endDate)) {
+        changeStartAndEndDate(date);
+      } else {
+        setNewDate({ ...newDate, startDate: date });
+      }
+    } else {
+      if (moment(date).isBefore(newDate.startDate)) {
+        changeStartAndEndDate(date);
+      } else {
+        setNewDate({ ...newDate, endDate: date });
+      }
+    }
+  };
+
+  const changeStartAndEndDate = (date: string) => {
+    setNewDate({ ...newDate, startDate: date, endDate: date });
+  };
+
+  const handleSetDate = () => {
+    const { startDate, endDate } = newDate;
+    onClickApprove(startDate, endDate);
+  };
+
+  // const renderDayInPicker = (props: PickersDayProps<moment.Moment>) => {
+  //   const { day, ...other } = props;
+  //   const { startDate, endDate } = newDate;
+  //   if (moment(startDate).isSame(endDate)) {
+  //     return <PickersDay {...props} />;
+  //   }
+  //   if (moment(startDate).isSame(day)) {
+  //     return (
+  //       <PickersDay
+  //         sx={{
+  //           borderTopRightRadius: 0,
+  //           borderBottomRightRadius: 0,
+  //           marginX: 0,
+  //           width: "40px",
+  //         }}
+  //         className="Mui-selected"
+  //         {...props}
+  //       />
+  //     );
+  //   }
+  //   if (moment(endDate).isSame(day)) {
+  //     return (
+  //       <PickersDay
+  //         sx={{
+  //           borderTopLeftRadius: 0,
+  //           borderBottomLeftRadius: 0,
+  //           marginX: 0,
+  //           width: "40px",
+  //         }}
+  //         className="Mui-selected"
+  //         {...props}
+  //       />
+  //     );
+  //   }
+  //   if (moment(startDate).isBefore(day) && moment(endDate).isAfter(day)) {
+  //     return (
+  //       <PickersDay
+  //         sx={{
+  //           borderRadius: 0,
+  //           marginX: 0,
+  //           width: "40px",
+  //         }}
+  //         className="Mui-selected"
+  //         {...props}
+  //       />
+  //     );
+  //   }
+  //   return <PickersDay {...props} />;
+  // };
+
+  return (
+    <Modal>
+      <DialogTitle id="alert-dialog-title">날짜 선택</DialogTitle>
+      <DialogContent>
+        {isSelectStartDate
+          ? `시작일: ${newDate.startDate}`
+          : `종료일: ${newDate.endDate}`}
+        <LocalizationProvider dateAdapter={AdapterMoment}>
+          <DateCalendar
+            views={["year", "month"]}
+            openTo="year"
+            value={moment(
+              isSelectStartDate ? newDate.startDate : newDate.endDate
+            )}
+            onChange={(newValue) => {
+              newValue && changeDate(newValue.format("YYYY-MM"));
+            }}
+            // slots={{
+            //   day: renderDayInPicker,
+            // }}
+          />
+        </LocalizationProvider>
+      </DialogContent>
+      <DialogActions>
+        {isSelectStartDate ? (
+          <Button onClick={() => setIsSelectStartDate(false)} autoFocus>
+            다음
+          </Button>
+        ) : (
+          <>
+            <Button onClick={() => setIsSelectStartDate(true)} autoFocus>
+              이전
+            </Button>
+            <Button onClick={handleSetDate} autoFocus>
+              설정
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Modal>
+  );
+}
+
+export default MonthPeriodPicker;

--- a/src/hooks/date-picker/hooks/useDatePicker.tsx
+++ b/src/hooks/date-picker/hooks/useDatePicker.tsx
@@ -4,6 +4,7 @@ import moment from "moment/moment";
 import MonthPicker from "@hooks/date-picker/components/MonthPicker.tsx";
 import TimePicker from "@hooks/date-picker/components/TimePicker.tsx";
 import MonthPeriodPicker from "@hooks/date-picker/components/MonthPeriodPicker.tsx";
+import DatePeriodPicker from "@hooks/date-picker/components/DatePeriodPicker.tsx";
 
 export const useDatePicker = () => {
   const { openOverlay, closeOverlay } = useOverlay();
@@ -18,6 +19,28 @@ export const useDatePicker = () => {
           }}
           onClickReject={(answer) => {
             resolve(answer);
+            closeOverlay();
+          }}
+        />
+      );
+    });
+  };
+
+  const openDayPeriodPicker = (
+    defaultStartDate: string,
+    defaultEndDate: string
+  ): Promise<{ start: string; end: string }> => {
+    return new Promise((resolve) => {
+      openOverlay(
+        <DatePeriodPicker
+          defaultStartDate={defaultStartDate}
+          defaultEndDate={defaultEndDate}
+          onClickApprove={(start, end) => {
+            resolve({ start, end });
+            closeOverlay();
+          }}
+          onClickReject={(start, end) => {
+            resolve({ start, end });
             closeOverlay();
           }}
         />
@@ -89,6 +112,7 @@ export const useDatePicker = () => {
 
   return {
     openDayPicker,
+    openDayPeriodPicker,
     openMonthPicker,
     openMonthPeriodPicker,
     openTimePicker,

--- a/src/hooks/date-picker/hooks/useDatePicker.tsx
+++ b/src/hooks/date-picker/hooks/useDatePicker.tsx
@@ -3,6 +3,7 @@ import DatePicker from "@hooks/date-picker/components/DatePicker.tsx";
 import moment from "moment/moment";
 import MonthPicker from "@hooks/date-picker/components/MonthPicker.tsx";
 import TimePicker from "@hooks/date-picker/components/TimePicker.tsx";
+import MonthPeriodPicker from "@hooks/date-picker/components/MonthPeriodPicker.tsx";
 
 export const useDatePicker = () => {
   const { openOverlay, closeOverlay } = useOverlay();
@@ -42,6 +43,28 @@ export const useDatePicker = () => {
     });
   };
 
+  const openMonthPeriodPicker = (
+    defaultStartDate: string,
+    defaultEndDate: string
+  ): Promise<{ start: string; end: string }> => {
+    return new Promise((resolve) => {
+      openOverlay(
+        <MonthPeriodPicker
+          defaultStartDate={defaultStartDate}
+          defaultEndDate={defaultEndDate}
+          onClickApprove={(start, end) => {
+            resolve({ start, end });
+            closeOverlay();
+          }}
+          onClickReject={(start, end) => {
+            resolve({ start, end });
+            closeOverlay();
+          }}
+        />
+      );
+    });
+  };
+
   const openTimePicker = ({
     defaultTime,
   }: {
@@ -67,6 +90,7 @@ export const useDatePicker = () => {
   return {
     openDayPicker,
     openMonthPicker,
+    openMonthPeriodPicker,
     openTimePicker,
     closeDatePicker: closeOverlay,
   };

--- a/src/legacies/assetManagement/ScheduleManagement.tsx
+++ b/src/legacies/assetManagement/ScheduleManagement.tsx
@@ -1,7 +1,0 @@
-function ScheduleManagement() {
-  return (
-    <>일정 관리</>
-  );
-}
-
-export default ScheduleManagement;

--- a/src/legacies/assetManagement/SpendingGoal/SpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/SpendingGoal.tsx
@@ -1,0 +1,5 @@
+function SpendingGoal() {
+  return <></>;
+}
+
+export default SpendingGoal;

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/EmptySpendCard.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/EmptySpendCard.tsx
@@ -1,0 +1,14 @@
+import { Box } from "@mui/material";
+import RoundedBorderBox from "@components/common/RoundedBorderBox.tsx";
+
+function EmptySpendCard() {
+  return (
+    <RoundedBorderBox greyBorder>
+      <Box p={2} textAlign="center" color="#8C919C">
+        지출 금액 정보가 없습니다.
+      </Box>
+    </RoundedBorderBox>
+  );
+}
+
+export default EmptySpendCard;

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.stories.tsx
@@ -14,12 +14,12 @@ const meta = {
 export default meta;
 
 const useStorybookMonth = () => {
-  const [yearMonth, setYearMonth] = useState("2023년5월");
+  const [yearMonth, setYearMonth] = useState("2023-05-01");
   const { openMonthPicker } = useDatePicker();
 
   const pickMonth = async () => {
     const newMonth = await openMonthPicker(yearMonth);
-    setYearMonth(newMonth.format("YYYY년MM월"));
+    setYearMonth(newMonth.format("YYYY-MM-DD"));
   };
 
   return {

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.stories.tsx
@@ -2,7 +2,6 @@ import MonthSpendingGoal from "@legacies/assetManagement/SpendingGoal/components
 import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
-import moment from "moment";
 
 const meta = {
   title: "AssetManagement/SpendingGoal/MonthSpendingGoal",

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.stories.tsx
@@ -1,0 +1,44 @@
+import MonthSpendingGoal from "@legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx";
+import { Meta } from "@storybook/react";
+import { useState } from "react";
+import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
+import moment from "moment";
+
+const meta = {
+  title: "AssetManagement/SpendingGoal/MonthSpendingGoal",
+  component: MonthSpendingGoal,
+  tags: ["autodocs"],
+  args: {},
+  argTypes: {},
+} satisfies Meta<typeof MonthSpendingGoal>;
+
+export default meta;
+
+const useStorybookMonth = () => {
+  const [yearMonth, setYearMonth] = useState("2023년5월");
+  const { openMonthPicker } = useDatePicker();
+
+  const pickMonth = async () => {
+    const newMonth = await openMonthPicker(yearMonth);
+    setYearMonth(newMonth.format("YYYY년MM월"));
+  };
+
+  return {
+    yearMonth,
+    pickMonth,
+  };
+};
+
+export const Example = () => {
+  const { yearMonth, pickMonth } = useStorybookMonth();
+
+  return (
+    <MonthSpendingGoal
+      date={yearMonth}
+      changeYearAndMonth={pickMonth}
+      handleModify={() => alert("modify")}
+      goal={"10000"}
+      spent={"1000"}
+    />
+  );
+};

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx
@@ -1,0 +1,82 @@
+import RoundedPaper from "@components/common/RoundedPaper.tsx";
+import { Box, IconButton, Stack, Typography } from "@mui/material";
+import filter_main from "@assets/icons/header/filter_main.svg";
+import RoundedBorderBox from "@components/common/RoundedBorderBox.tsx";
+import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
+import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
+
+export interface MonthSpendingGoal {
+  date: string;
+  changeYearAndMonth: () => void;
+  handleModify: () => void;
+  goal: string;
+  spent: string;
+}
+
+function MonthSpendingGoal({
+  date,
+  changeYearAndMonth,
+  handleModify,
+  goal,
+  spent,
+}: MonthSpendingGoal) {
+  return (
+    <Box mt="30px">
+      <RoundedPaper my={2}>
+        <Stack
+          direction="row"
+          alignItems="center"
+          onClick={changeYearAndMonth}
+          mb={3}
+        >
+          <Typography variant="h2">{date}</Typography>
+          <ExpandMoreRoundedIcon />
+        </Stack>
+
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          pb={1}
+        >
+          <Box sx={{ fontSize: "18px", fontWeight: "700" }}>지출 목표 금액</Box>
+          <IconButton color="primary" onClick={handleModify} sx={{ p: 0 }}>
+            <img src={filter_main} alt="filter" />
+          </IconButton>
+        </Stack>
+        <RoundedBorderBox>
+          <Box
+            sx={{
+              typography: "h6",
+              fontWeight: "bold",
+              color: "primary.main",
+              textAlign: "end",
+              p: 2,
+            }}
+          >
+            {getAmount(goal).toLocaleString()}원
+          </Box>
+        </RoundedBorderBox>
+
+        <Box sx={{ fontSize: "18px", fontWeight: "700" }} pb={1} pt={2}>
+          지출 금액
+        </Box>
+        <RoundedBorderBox>
+          <Box
+            sx={{
+              typography: "h6",
+              fontWeight: "bold",
+              color: "primary.main",
+              textAlign: "end",
+              p: 2,
+            }}
+          >
+            {getAmount(spent).toLocaleString()}원
+          </Box>
+        </RoundedBorderBox>
+      </RoundedPaper>
+    </Box>
+  );
+}
+
+export default MonthSpendingGoal;

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx
@@ -4,6 +4,8 @@ import filter_main from "@assets/icons/header/filter_main.svg";
 import RoundedBorderBox from "@components/common/RoundedBorderBox.tsx";
 import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
 import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
+import moment from "moment";
+import EmptySpendCard from "@legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/EmptySpendCard.tsx";
 
 export interface MonthSpendingGoalProps {
   date: string;
@@ -29,7 +31,9 @@ function MonthSpendingGoal({
           onClick={changeYearAndMonth}
           mb={3}
         >
-          <Typography variant="h2">{date}</Typography>
+          <Typography variant="h2">
+            {moment(date).format("YYYY년 M월")}
+          </Typography>
           <ExpandMoreRoundedIcon />
         </Stack>
 
@@ -61,19 +65,23 @@ function MonthSpendingGoal({
         <Box sx={{ fontSize: "18px", fontWeight: "700" }} pb={1} pt={2}>
           지출 금액
         </Box>
-        <RoundedBorderBox>
-          <Box
-            sx={{
-              typography: "h6",
-              fontWeight: "bold",
-              color: "primary.main",
-              textAlign: "end",
-              p: 2,
-            }}
-          >
-            {getAmount(spent).toLocaleString()}원
-          </Box>
-        </RoundedBorderBox>
+        {moment().isAfter(date) ? (
+          <EmptySpendCard />
+        ) : (
+          <RoundedBorderBox>
+            <Box
+              sx={{
+                typography: "h6",
+                fontWeight: "bold",
+                color: "primary.main",
+                textAlign: "end",
+                p: 2,
+              }}
+            >
+              {getAmount(spent).toLocaleString()}원
+            </Box>
+          </RoundedBorderBox>
+        )}
       </RoundedPaper>
     </Box>
   );

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx
@@ -5,7 +5,7 @@ import RoundedBorderBox from "@components/common/RoundedBorderBox.tsx";
 import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
 import ExpandMoreRoundedIcon from "@mui/icons-material/ExpandMoreRounded";
 
-export interface MonthSpendingGoal {
+export interface MonthSpendingGoalProps {
   date: string;
   changeYearAndMonth: () => void;
   handleModify: () => void;
@@ -19,7 +19,7 @@ function MonthSpendingGoal({
   handleModify,
   goal,
   spent,
-}: MonthSpendingGoal) {
+}: MonthSpendingGoalProps) {
   return (
     <Box mt="30px">
       <RoundedPaper my={2}>

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/ModifyModal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/ModifyModal.stories.tsx
@@ -1,0 +1,43 @@
+import ModifyModal from "@legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/ModifyModal.tsx";
+import { Meta } from "@storybook/react";
+import { Box, Button } from "@mui/material";
+import { useModal } from "@hooks/modal/useModal.tsx";
+import { useState } from "react";
+
+const meta = {
+  title: "AssetManagement/SpendingGoal/MonthSpendingGoal/ModifyModal",
+  component: ModifyModal,
+  tags: ["autodocs"],
+  args: {},
+  argTypes: {},
+} satisfies Meta<typeof ModifyModal>;
+
+export default meta;
+
+export const Example = () => {
+  const { openModal, closeModal } = useModal();
+  const [value, setValue] = useState(0);
+
+  const handleChange = (v: number) => {
+    setValue(v);
+  };
+
+  const handleModify = () => {
+    openModal({
+      modalElement: (
+        <ModifyModal
+          closeModal={closeModal}
+          value={value}
+          month="5"
+          handleSubmit={handleChange}
+        />
+      ),
+      isBackdropClickable: true,
+    });
+  };
+  return (
+    <>
+      <Box>value: {value}</Box> <Button onClick={handleModify}>modify</Button>
+    </>
+  );
+};

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/ModifyModal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/ModifyModal.tsx
@@ -1,0 +1,89 @@
+import {
+  Button,
+  Divider,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  OutlinedInput,
+  Stack,
+  Typography,
+} from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
+import reset from "@assets/icons/reset.svg";
+import { useState } from "react";
+
+export interface ModifyModalProps {
+  month: string;
+  value: number;
+  closeModal: () => void;
+  handleSubmit: (v: number) => void;
+}
+
+function ModifyModal({
+  closeModal,
+  handleSubmit,
+  value,
+  month,
+}: ModifyModalProps) {
+  const [newValue, setNewValue] = useState(value);
+  const handleReset = () => setNewValue(0);
+  return (
+    <Stack p={2} spacing={1}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <IconButton onClick={handleReset}>
+          <img src={reset} alt="reset" width="24px" height="24px" />
+        </IconButton>
+        <Typography sx={{ fontWeight: 500, fontSize: "17px" }}>
+          {`${month}월 지출 목표액`}
+        </Typography>
+        <IconButton onClick={closeModal}>
+          <ClearIcon />
+        </IconButton>
+      </Stack>
+
+      <Divider sx={{ marginY: 1 }} />
+
+      <FormControl fullWidth>
+        <OutlinedInput
+          id="goal_amount"
+          endAdornment={<InputAdornment position="end">원</InputAdornment>}
+          value={newValue.toLocaleString()}
+          onChange={(e) =>
+            setNewValue(parseInt(e.target.value.replaceAll(",", "")))
+          }
+          inputProps={{
+            style: { textAlign: "right" },
+            step: 10,
+          }}
+          type="text"
+          onFocus={(e) => e.target.select()}
+          color="primary"
+        />
+      </FormControl>
+
+      <Stack direction="row" spacing={1}>
+        <Button
+          fullWidth
+          variant="contained"
+          color="secondary"
+          onClick={closeModal}
+        >
+          취소
+        </Button>
+
+        <Button
+          fullWidth
+          variant="contained"
+          onClick={() => {
+            handleSubmit(newValue);
+            closeModal();
+          }}
+        >
+          설정
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default ModifyModal;

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/index.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/index.ts
@@ -1,0 +1,3 @@
+import ModifyModal from "@legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/components/ModifyModal/ModifyModal.tsx";
+
+export default ModifyModal;

--- a/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/index.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/index.ts
@@ -1,0 +1,3 @@
+import MonthSpendingGoal from "@legacies/assetManagement/SpendingGoal/components/MonthSpendingGoal/MonthSpendingGoal.tsx";
+
+export default MonthSpendingGoal;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/ModifyRegularSpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/ModifyRegularSpendingGoal.tsx
@@ -1,0 +1,112 @@
+import { Box, Button, InputBase, Stack } from "@mui/material";
+import GoalCard from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard";
+import {
+  Highlight,
+  HighLightInput,
+} from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.styles.ts";
+import { ChangeEvent, useState } from "react";
+import calendar_primary from "@assets/icons/bottom/calendar_primary.svg";
+import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
+
+export interface ModifyRegularSpendingGoalProps {
+  goal: string;
+  startDate: string;
+  endDate: string;
+  closeModify: () => void;
+  handleSubmit: (form: Form) => void;
+}
+
+export interface Form {
+  goal: string;
+  start_date: string;
+  end_date: string;
+}
+
+function ModifyRegularSpendingGoal({
+  goal,
+  startDate,
+  endDate,
+  closeModify,
+  handleSubmit,
+}: ModifyRegularSpendingGoalProps) {
+  const [form, setForm] = useState({
+    goal: goal,
+    start_date: startDate,
+    end_date: endDate,
+  });
+  const handleChange = (state: ChangeEvent<HTMLInputElement>) => {
+    console.log(state.target.value.replaceAll(",", ""));
+    setForm({
+      ...form,
+      [state.target.id]: state.target.value.replaceAll(",", ""),
+    });
+  };
+
+  return (
+    <Stack spacing="25px">
+      <GoalCard
+        title={"지출 목표액"}
+        start={<>한달 기준</>}
+        end={
+          <Stack direction="row" spacing={1} alignItems="center">
+            <HighLightInput
+              id="goal"
+              onChange={handleChange}
+              value={getAmount(form.goal).toLocaleString()}
+            />
+            <Box>원</Box>
+          </Stack>
+        }
+      />
+      <GoalCard
+        title={"기간"}
+        Icon={
+          <Box pt={1.5}>
+            <img
+              src={calendar_primary}
+              alt="calendar_primary"
+              width={20}
+              height={20}
+            />
+          </Box>
+        }
+        start={
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Highlight>{form.start_date}</Highlight>
+            <Box>부터</Box>
+          </Stack>
+        }
+        end={
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Highlight>{form.end_date}</Highlight>
+            <Box>까지</Box>
+          </Stack>
+        }
+      />
+
+      <Stack direction="row" spacing={1}>
+        <Button
+          fullWidth
+          variant="contained"
+          color="secondary"
+          onClick={closeModify}
+        >
+          취소
+        </Button>
+
+        <Button
+          fullWidth
+          variant="contained"
+          onClick={() => {
+            handleSubmit(form);
+            closeModify();
+          }}
+        >
+          설정
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default ModifyRegularSpendingGoal;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/ModifyRegularSpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/ModifyRegularSpendingGoal.tsx
@@ -7,6 +7,8 @@ import {
 import { ChangeEvent, useState } from "react";
 import calendar_primary from "@assets/icons/bottom/calendar_primary.svg";
 import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
+import moment from "moment/moment";
+import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
 
 export interface ModifyRegularSpendingGoalProps {
   goal: string;
@@ -29,6 +31,7 @@ function ModifyRegularSpendingGoal({
   closeModify,
   handleSubmit,
 }: ModifyRegularSpendingGoalProps) {
+  const { openMonthPeriodPicker } = useDatePicker();
   const [form, setForm] = useState({
     goal: goal,
     start_date: startDate,
@@ -39,6 +42,16 @@ function ModifyRegularSpendingGoal({
     setForm({
       ...form,
       [state.target.id]: state.target.value.replaceAll(",", ""),
+    });
+  };
+
+  const handleChandlePeriod = async () => {
+    const newDate = await openMonthPeriodPicker(form.start_date, form.end_date);
+    if (!newDate) return;
+    setForm({
+      ...form,
+      start_date: newDate.start,
+      end_date: newDate.end,
     });
   };
 
@@ -61,7 +74,7 @@ function ModifyRegularSpendingGoal({
       <GoalCard
         title={"기간"}
         Icon={
-          <Box pt={1.5}>
+          <Box pt={1.5} onClick={handleChandlePeriod}>
             <img
               src={calendar_primary}
               alt="calendar_primary"

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta } from "@storybook/react";
+import RegularSpendingGoal from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/index.ts";
+import { RegularSpendingGoalProps } from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx";
+
+const meta = {
+  title: "AssetManagement/SpendingGoal/RegularSpendingGoal",
+  component: RegularSpendingGoal,
+  tags: ["autodocs"],
+  args: {
+    handleModify: () => alert("modify"),
+    goal: "100000",
+    startDate: "2024-01",
+    endDate: "2024-02",
+  },
+  argTypes: {},
+} satisfies Meta<typeof RegularSpendingGoal>;
+
+export default meta;
+
+export const Default = (args: RegularSpendingGoalProps) => {
+  return <RegularSpendingGoal {...args} />;
+};

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta } from "@storybook/react";
 import RegularSpendingGoal from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/index.ts";
 import { RegularSpendingGoalProps } from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx";
+import { useState } from "react";
+import { Form } from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/ModifyRegularSpendingGoal.tsx";
 
 const meta = {
   title: "AssetManagement/SpendingGoal/RegularSpendingGoal",
@@ -8,6 +10,7 @@ const meta = {
   tags: ["autodocs"],
   args: {
     handleModify: () => alert("modify"),
+    isModify: false,
     goal: "100000",
     startDate: "2024-01",
     endDate: "2024-02",
@@ -19,4 +22,28 @@ export default meta;
 
 export const Default = (args: RegularSpendingGoalProps) => {
   return <RegularSpendingGoal {...args} />;
+};
+
+export const Example = () => {
+  const [isModify, setIsModify] = useState(false);
+  const [value, setValue] = useState({
+    goal: "10000000",
+    start_date: "2024-01",
+    end_date: "2024-02",
+  });
+  const handleSubmit = (form: Form) => {
+    setIsModify(false);
+    setValue(form);
+  };
+  return (
+    <RegularSpendingGoal
+      handleModify={() => setIsModify(true)}
+      handleSubmit={handleSubmit}
+      closeModify={() => setIsModify(false)}
+      isModify={isModify}
+      goal={value.goal}
+      startDate={value.start_date}
+      endDate={value.end_date}
+    />
+  );
 };

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.stories.tsx
@@ -3,6 +3,9 @@ import RegularSpendingGoal from "@legacies/assetManagement/SpendingGoal/componen
 import { RegularSpendingGoalProps } from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx";
 import { useState } from "react";
 import { Form } from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/ModifyRegularSpendingGoal.tsx";
+import { useModal } from "@hooks/modal/useModal.tsx";
+import ConfirmModal from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal";
+import { Button } from "@mui/material";
 
 const meta = {
   title: "AssetManagement/SpendingGoal/RegularSpendingGoal",
@@ -26,24 +29,52 @@ export const Default = (args: RegularSpendingGoalProps) => {
 
 export const Example = () => {
   const [isModify, setIsModify] = useState(false);
+  const [haveGoal, setHaveGoal] = useState(false);
   const [value, setValue] = useState({
     goal: "10000000",
     start_date: "2024-01",
     end_date: "2024-02",
   });
+
+  const { openModal, closeModal } = useModal();
+
   const handleSubmit = (form: Form) => {
+    if (haveGoal) {
+      openModal({
+        modalElement: (
+          <ConfirmModal
+            closeModal={closeModal}
+            handleApprove={() => {
+              alert("지출 목표 변경");
+              closeModal();
+            }}
+            handleReject={() => {
+              alert("지출 목표 유지");
+              closeModal();
+            }}
+          />
+        ),
+        isBackdropClickable: false,
+      });
+    }
     setIsModify(false);
     setValue(form);
   };
+
   return (
-    <RegularSpendingGoal
-      handleModify={() => setIsModify(true)}
-      handleSubmit={handleSubmit}
-      closeModify={() => setIsModify(false)}
-      isModify={isModify}
-      goal={value.goal}
-      startDate={value.start_date}
-      endDate={value.end_date}
-    />
+    <>
+      <RegularSpendingGoal
+        handleModify={() => setIsModify(true)}
+        handleSubmit={handleSubmit}
+        closeModify={() => setIsModify(false)}
+        isModify={isModify}
+        goal={value.goal}
+        startDate={value.start_date}
+        endDate={value.end_date}
+      />
+      <Button onClick={() => setHaveGoal((prevState) => !prevState)}>
+        지출 목표 설정 여부 변경
+      </Button>
+    </>
   );
 };

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.styles.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.styles.ts
@@ -1,0 +1,7 @@
+import styled from "@emotion/styled";
+
+export const Highlight = styled.span`
+  font-weight: 700;
+  font-size: 18px;
+  color: #735bf2;
+`;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.styles.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.styles.ts
@@ -5,3 +5,11 @@ export const Highlight = styled.span`
   font-size: 18px;
   color: #735bf2;
 `;
+
+export const HighLightInput = styled.input`
+  border: none;
+  font-weight: 700;
+  font-size: 18px;
+  color: #735bf2;
+  text-align: end;
+`;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx
@@ -4,9 +4,15 @@ import filter_main from "@assets/icons/header/filter_main.svg";
 import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
 import GoalCard from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard";
 import { Highlight } from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.styles.ts";
+import ModifyRegularSpendingGoal, {
+  Form,
+} from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/ModifyRegularSpendingGoal.tsx";
 
 export interface RegularSpendingGoalProps {
   handleModify: () => void;
+  handleSubmit: (form: Form) => void;
+  closeModify: () => void;
+  isModify: boolean;
   goal: string;
   startDate: string;
   endDate: string;
@@ -14,6 +20,9 @@ export interface RegularSpendingGoalProps {
 
 function RegularSpendingGoal({
   handleModify,
+  handleSubmit,
+  closeModify,
+  isModify,
   goal,
   startDate,
   endDate,
@@ -34,34 +43,43 @@ function RegularSpendingGoal({
             <img src={filter_main} alt="filter" />
           </IconButton>
         </Stack>
-
-        <Stack spacing="25px">
-          <GoalCard
-            title={"지출 목표액"}
-            start={<>한달 기준</>}
-            end={
-              <Stack direction="row" spacing={1} alignItems="center">
-                <Highlight>{getAmount(goal)}</Highlight>
-                <Box>원</Box>
-              </Stack>
-            }
+        {isModify ? (
+          <ModifyRegularSpendingGoal
+            goal={goal}
+            startDate={startDate}
+            endDate={endDate}
+            closeModify={closeModify}
+            handleSubmit={handleSubmit}
           />
-          <GoalCard
-            title={"기간"}
-            start={
-              <Stack direction="row" spacing={1} alignItems="center">
-                <Highlight>{startDate}</Highlight>
-                <Box>부터</Box>
-              </Stack>
-            }
-            end={
-              <Stack direction="row" spacing={1} alignItems="center">
-                <Highlight>{endDate}</Highlight>
-                <Box>까지</Box>
-              </Stack>
-            }
-          />
-        </Stack>
+        ) : (
+          <Stack spacing="25px">
+            <GoalCard
+              title={"지출 목표액"}
+              start={<>한달 기준</>}
+              end={
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Highlight>{getAmount(goal).toLocaleString()}</Highlight>
+                  <Box>원</Box>
+                </Stack>
+              }
+            />
+            <GoalCard
+              title={"기간"}
+              start={
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Highlight>{startDate}</Highlight>
+                  <Box>부터</Box>
+                </Stack>
+              }
+              end={
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <Highlight>{endDate}</Highlight>
+                  <Box>까지</Box>
+                </Stack>
+              }
+            />
+          </Stack>
+        )}
       </RoundedPaper>
     </Box>
   );

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx
@@ -1,0 +1,70 @@
+import RoundedPaper from "@components/common/RoundedPaper.tsx";
+import { Box, IconButton, Stack } from "@mui/material";
+import filter_main from "@assets/icons/header/filter_main.svg";
+import { getAmount } from "@legacies/assetManagement/SavingsGoalContainer/utils.ts";
+import GoalCard from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard";
+import { Highlight } from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.styles.ts";
+
+export interface RegularSpendingGoalProps {
+  handleModify: () => void;
+  goal: string;
+  startDate: string;
+  endDate: string;
+}
+
+function RegularSpendingGoal({
+  handleModify,
+  goal,
+  startDate,
+  endDate,
+}: RegularSpendingGoalProps) {
+  return (
+    <Box mt="30px">
+      <RoundedPaper my={2}>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          mb={"17px"}
+        >
+          <Box sx={{ fontSize: "18px", fontWeight: "700" }}>
+            정기 지출 목표액
+          </Box>
+          <IconButton color="primary" onClick={handleModify}>
+            <img src={filter_main} alt="filter" />
+          </IconButton>
+        </Stack>
+
+        <Stack spacing="25px">
+          <GoalCard
+            title={"지출 목표액"}
+            start={<>한달 기준</>}
+            end={
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Highlight>{getAmount(goal)}</Highlight>
+                <Box>원</Box>
+              </Stack>
+            }
+          />
+          <GoalCard
+            title={"기간"}
+            start={
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Highlight>{startDate}</Highlight>
+                <Box>부터</Box>
+              </Stack>
+            }
+            end={
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Highlight>{endDate}</Highlight>
+                <Box>까지</Box>
+              </Stack>
+            }
+          />
+        </Stack>
+      </RoundedPaper>
+    </Box>
+  );
+}
+
+export default RegularSpendingGoal;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/ConfirmModal.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/ConfirmModal.stories.tsx
@@ -1,0 +1,39 @@
+import { useModal } from "@hooks/modal/useModal.tsx";
+import ConfirmModal from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/index.ts";
+import { Button } from "@mui/material";
+import { Meta } from "@storybook/react";
+
+export const Default = () => {
+  const { openModal, closeModal } = useModal();
+
+  const handleOpenConfirmModal = () => {
+    openModal({
+      modalElement: (
+        <ConfirmModal
+          closeModal={closeModal}
+          handleApprove={() => {
+            alert("approve!");
+            closeModal();
+          }}
+          handleReject={() => {
+            alert("reject!");
+            closeModal();
+          }}
+        />
+      ),
+      isBackdropClickable: true,
+    });
+  };
+
+  return <Button onClick={handleOpenConfirmModal}>모달</Button>;
+};
+
+const meta = {
+  title: "Assetmanagement/SpendingGoal/RegularSpendingGoal/ConfirmModal",
+  component: Default,
+  tags: ["autodocs"],
+  args: {},
+  argTypes: {},
+} satisfies Meta<typeof Default>;
+
+export default meta;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/ConfirmModal.tsx
@@ -1,0 +1,48 @@
+import { Box, Button, IconButton, Stack, Typography } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
+
+export interface ConfirmModalProps {
+  closeModal: () => void;
+  handleApprove: () => void;
+  handleReject: () => void;
+}
+
+function ConfirmModal({
+  closeModal,
+  handleReject,
+  handleApprove,
+}: ConfirmModalProps) {
+  return (
+    <Stack spacing={3} p="20px">
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        sx={{ pb: "12px", borderBottom: "1px solid #C8CBD0" }}
+      >
+        <Box width={40} />
+        <Typography variant="h1">알림</Typography>
+        <IconButton onClick={closeModal}>
+          <ClearIcon />
+        </IconButton>
+      </Stack>
+
+      <Box
+        sx={{ textAlign: "center", whiteSpace: "pre-line", fontSize: "16px" }}
+      >
+        {`이미 설정한 지출 목표액이 있습니다.\n정기 지출 목표액으로 변경하시겠습니까?`}
+      </Box>
+
+      <Stack spacing={1}>
+        <Button variant="contained" onClick={handleApprove}>
+          예(설정한 정기목표액으로 일괄변경)
+        </Button>
+        <Button variant="contained" color="secondary" onClick={handleReject}>
+          아니오(설정한 지출 목표액 유지)
+        </Button>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default ConfirmModal;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/index.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/index.ts
@@ -1,0 +1,3 @@
+import ConfirmModal from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/ConfirmModal/ConfirmModal.tsx";
+
+export default ConfirmModal;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.stories.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.stories.tsx
@@ -1,0 +1,12 @@
+import GoalCard from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.tsx";
+import { Meta } from "@storybook/react";
+
+const meta = {
+  title: "AssetManagement/SpendingGoal/RegularSpendingGoal/GoalCard",
+  component: GoalCard,
+  tags: ["autodocs"],
+  args: { title: "지출 목표액", start: <>한달 목표</>, end: <>100000 원</> },
+  argTypes: {},
+} satisfies Meta<typeof GoalCard>;
+
+export default meta;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.styles.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.styles.ts
@@ -1,0 +1,20 @@
+import styled from "@emotion/styled";
+
+export const GoalHeader = styled.div`
+  background-color: #eae1fd;
+  color: #735bf2;
+  width: 100px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  text-align: center;
+  font-weight: 700;
+  font-size: 14px;
+`;
+
+export const GoalBody = styled.div`
+  padding-top: 10px;
+  padding-bottom: 7px;
+  padding-left: 3px;
+  border-bottom: 1px solid #6d29f6;
+  font-size: 12px;
+`;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.tsx
@@ -7,14 +7,16 @@ import { ReactNode } from "react";
 
 export interface GoalCardProps {
   title: string;
+  Icon?: ReactNode;
   start: ReactNode;
   end: ReactNode;
 }
 
-function GoalCard({ title, start, end }: GoalCardProps) {
+function GoalCard({ Icon, title, start, end }: GoalCardProps) {
   return (
     <Stack>
       <GoalHeader>{title}</GoalHeader>
+      {Icon}
       <GoalBody>
         <Stack
           direction="row"

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.tsx
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.tsx
@@ -1,0 +1,32 @@
+import { Box, Stack, Typography } from "@mui/material";
+import {
+  GoalHeader,
+  GoalBody,
+} from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.styles.ts";
+import { ReactNode } from "react";
+
+export interface GoalCardProps {
+  title: string;
+  start: ReactNode;
+  end: ReactNode;
+}
+
+function GoalCard({ title, start, end }: GoalCardProps) {
+  return (
+    <Stack>
+      <GoalHeader>{title}</GoalHeader>
+      <GoalBody>
+        <Stack
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Box>{start}</Box>
+          <Box>{end}</Box>
+        </Stack>
+      </GoalBody>
+    </Stack>
+  );
+}
+
+export default GoalCard;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/index.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/index.ts
@@ -1,0 +1,3 @@
+import GoalCard from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/components/GoalCard/GoalCard.tsx";
+
+export default GoalCard;

--- a/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/index.ts
+++ b/src/legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/index.ts
@@ -1,0 +1,3 @@
+import RegularSpendingGoal from "@legacies/assetManagement/SpendingGoal/components/RegularSpendingGoal/RegularSpendingGoal.tsx";
+
+export default RegularSpendingGoal;

--- a/src/legacies/assetManagement/SpendingGoal/index.ts
+++ b/src/legacies/assetManagement/SpendingGoal/index.ts
@@ -1,0 +1,3 @@
+import SpendingGoal from "@legacies/assetManagement/SpendingGoal/SpendingGoal.tsx";
+
+export default SpendingGoal;


### PR DESCRIPTION
자산관리의 지출 목표 설정페이지 컴포넌트 구현을 진행했습니다.

또한, 정기 지출 설정 시 필요한 기간 선택을 위한 훅을 추가했습니다.

- 한 달 지출 목표
  - 지출 목표 카드 구현
  - 지출 목표 설정 모달 구현
- 정기 지출 목표
  - 정기 지출 목표 카드 구현
  - 정기 지출 수정 카드 구현
- 기간 설정 구현

close #251