### PR TITLE
refactor: ScheduleDrawer 수정

### DIFF
--- a/src/components/ScheduleDrawer/ScheduleDrawer.tsx
+++ b/src/components/ScheduleDrawer/ScheduleDrawer.tsx
@@ -51,7 +51,13 @@ function ScheduleDrawer({ handleClose, resetSchedule }: ScheduleDrawerProps) {
 
   return (
     <div>
-      <Box sx={{ height: "100%", pt: 1, mb: 3 }}>
+      <Box
+        sx={{
+          height: "100%",
+          pt: 1,
+          mb: 3,
+        }}
+      >
         <ScheduleDrawerHeader
           value={value}
           handleChange={handleChange}

--- a/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
+++ b/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
@@ -220,6 +220,7 @@ export const useScheduleForm = () => {
             kind_type: value,
           },
           period,
+          is_all_day: true,
         })
       );
       return;

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/InputDateTime.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/InputDateTime.tsx
@@ -12,11 +12,12 @@ interface InputDateTimeProps {
   time?: string;
   type: InputDateTimeType;
   showError: boolean;
+  isAllDay?: boolean;
 }
 
 export type InputDateTimeType = "start" | "end";
 
-function InputDateTime({ date, time, type }: InputDateTimeProps) {
+function InputDateTime({ date, time, type, isAllDay }: InputDateTimeProps) {
   const { updateSchedule } = useScheduleForm();
 
   const title = SCHEDULE_DRAWER[type];
@@ -52,6 +53,17 @@ function InputDateTime({ date, time, type }: InputDateTimeProps) {
       });
     }
   };
+
+  if (isAllDay) {
+    return (
+      <Box sx={{ py: 1 }}>
+        <SelectDateTime
+          dateTime={moment(date).format("YYYY/MM/DD dddd")}
+          onClick={onClickDateField}
+        />
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ py: 1 }}>

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/InputDateTime.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/InputDateTime.tsx
@@ -6,7 +6,6 @@ import "moment/dist/locale/ko";
 import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
 import { useScheduleForm } from "../../../../hooks/useScheduleForm.ts";
 import SelectDateTime from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/select/SelectDateTime/SelectDateTime.tsx";
-import { RefObject } from "react";
 
 interface InputDateTimeProps {
   date?: string;
@@ -17,7 +16,7 @@ interface InputDateTimeProps {
 
 export type InputDateTimeType = "start" | "end";
 
-function InputDateTime({ date, time, type, showError }: InputDateTimeProps) {
+function InputDateTime({ date, time, type }: InputDateTimeProps) {
   const { updateSchedule } = useScheduleForm();
 
   const title = SCHEDULE_DRAWER[type];

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/InputDateTime.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/InputDateTime.tsx
@@ -1,13 +1,12 @@
-import { Box, Grid, InputAdornment, Typography } from "@mui/material";
+import { Box, Grid, Typography } from "@mui/material";
 import { UpdateStateInterface } from "@app/types/common.ts";
 import { SCHEDULE_DRAWER } from "@constants/schedule.ts";
 import moment from "moment";
 import "moment/dist/locale/ko";
-import { DateField, LocalizationProvider } from "@mui/x-date-pickers";
-import { AdapterMoment } from "@mui/x-date-pickers/AdapterMoment";
 import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
 import { useScheduleForm } from "../../../../hooks/useScheduleForm.ts";
 import SelectDateTime from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/select/SelectDateTime/SelectDateTime.tsx";
+import { RefObject } from "react";
 
 interface InputDateTimeProps {
   date?: string;
@@ -19,7 +18,7 @@ interface InputDateTimeProps {
 export type InputDateTimeType = "start" | "end";
 
 function InputDateTime({ date, time, type, showError }: InputDateTimeProps) {
-  const { scheduleForm, updateSchedule } = useScheduleForm();
+  const { updateSchedule } = useScheduleForm();
 
   const title = SCHEDULE_DRAWER[type];
   const { openDayPicker, openTimePicker } = useDatePicker();

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
@@ -50,6 +50,7 @@ function DateInput({ showError }: DateInputProps) {
               },
             })
           }
+          disabled={scheduleForm?.repeat.kind_type !== "none"}
         />
       </Stack>
     </Stack>

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
@@ -46,7 +46,7 @@ function DateInput({ showError }: DateInputProps) {
             changeAllDay({
               target: {
                 value: !scheduleForm?.is_all_day,
-                name: "all_day",
+                name: "is_all_day",
               },
             })
           }

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
@@ -10,6 +10,7 @@ interface DateInputProps {
 
 function DateInput({ showError }: DateInputProps) {
   const { scheduleForm, updateAllDay } = useScheduleForm();
+  const isAllDay = scheduleForm?.is_all_day ?? false;
 
   const changeAllDay = (state: {
     target: { value: boolean; name: string };
@@ -24,14 +25,17 @@ function DateInput({ showError }: DateInputProps) {
         time={scheduleForm?.start_time}
         type="start"
         showError={showError}
+        isAllDay={isAllDay}
       />
 
-      <InputDateTime
-        date={scheduleForm?.end_date}
-        time={scheduleForm?.end_time}
-        type="end"
-        showError={showError}
-      />
+      {!isAllDay && (
+        <InputDateTime
+          date={scheduleForm?.end_date}
+          time={scheduleForm?.end_time}
+          type="end"
+          showError={showError}
+        />
+      )}
 
       <Stack
         direction="row"
@@ -41,7 +45,7 @@ function DateInput({ showError }: DateInputProps) {
       >
         <Typography variant="h4">{SCHEDULE_DRAWER.all_day}</Typography>
         <SwitchButton
-          checked={scheduleForm?.is_all_day ?? true}
+          checked={isAllDay}
           handleChange={() =>
             changeAllDay({
               target: {

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/DateInput/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack, Typography } from "@mui/material";
+import { Stack, Typography } from "@mui/material";
 import SwitchButton from "@components/common/SwitchButton.tsx";
 import InputDateTime from "./InputDateTime.tsx";
 import { SCHEDULE_DRAWER } from "@constants/schedule.ts";

--- a/src/components/common/SwitchButton.tsx
+++ b/src/components/common/SwitchButton.tsx
@@ -3,15 +3,17 @@ import { Switch, SwitchProps, styled } from "@mui/material";
 interface SwitchButtonProps {
   checked: boolean;
   handleChange: () => void;
+  disabled?: boolean;
 }
 
-function SwitchButton({ checked, handleChange }: SwitchButtonProps) {
+function SwitchButton({ checked, handleChange, disabled }: SwitchButtonProps) {
   return (
     <CustomSwitchButton
       size="small"
       inputProps={{ "aria-label": "controlled" }}
       checked={checked}
       onChange={handleChange}
+      disabled={disabled}
     />
   );
 }

--- a/src/hooks/date-picker/components/SelectTime.tsx
+++ b/src/hooks/date-picker/components/SelectTime.tsx
@@ -1,9 +1,7 @@
 import {
   Box,
-  Button,
   InputBase,
   Stack,
-  TextField,
   ToggleButton,
   ToggleButtonGroup,
   Typography,

--- a/src/hooks/date-picker/components/TimePicker.tsx
+++ b/src/hooks/date-picker/components/TimePicker.tsx
@@ -1,7 +1,6 @@
-import { Button, Divider, Stack, Typography } from "@mui/material";
+import { Button, Dialog, Stack, Typography } from "@mui/material";
 import { useState } from "react";
 import SelectTime from "@hooks/date-picker/components/SelectTime.tsx";
-import Modal from "@hooks/modal/Modal.tsx";
 
 export interface TimePickerProps {
   defaultTime: string;
@@ -42,7 +41,13 @@ function TimePicker({
   };
 
   return (
-    <Modal>
+    <Dialog
+      open={true}
+      sx={{
+        zIndex: (theme) => theme.zIndex.drawer + 100,
+        paddingX: 4,
+      }}
+    >
       <Stack p="20px" spacing={3}>
         <Typography
           variant="h1"
@@ -75,7 +80,7 @@ function TimePicker({
           </Button>
         </Stack>
       </Stack>
-    </Modal>
+    </Dialog>
   );
 }
 

--- a/src/hooks/useScheduleDrawer.tsx
+++ b/src/hooks/useScheduleDrawer.tsx
@@ -41,6 +41,12 @@ export const useScheduleDrawer = () => {
           ModalProps={{
             keepMounted: true,
           }}
+          PaperProps={{
+            style: {
+              borderTopLeftRadius: "20px",
+              borderTopRightRadius: "20px",
+            },
+          }}
         >
           <ScheduleDrawer
             handleClose={closeOverlay}


### PR DESCRIPTION
ScheduleDrawer의 기능 수정을 진행했습니다.

- 하루종일 switch의 on/off가 동작하지 않는 오류를 해결했습니다.
- 반복기능을 활성화했을 경우 하루종일을 활성화하고 수정 불가능하게 설정했습니다.
- 일정 시간 입력이 불가능한 오류를 해결했습니다.
  - mui의 Backdrop을 사용하던 자체 Modal 컴포넌트 대신 mui의 Dialog컴포넌트를 사용해 해결했습니다.
- 하루종일 활성화시 시간을 숨기고 날짜만 보이도록 수정했습니다.

close #255