### PR TITLE
refactor: home/month mock api response 구조 수정

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -180,8 +180,9 @@ export const handlers = [
         ctx.json({
           income: "0",
           available: "0",
-          today_schedule: [],
+          data: [],
           expense: "0",
+          count: 0,
         })
       );
     }
@@ -191,8 +192,9 @@ export const handlers = [
       ctx.json({
         income: "10000",
         available: "2000",
-        today_schedule: monthSchedules,
+        data: monthSchedules,
         expense: "8000",
+        count: monthSchedules.length,
       })
     );
   }),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -92,32 +92,6 @@ export const handlers = [
     return res(ctx.delay(1000), ctx.status(200), ctx.json(true));
   }),
 
-  rest.post(`${DOMAIN}/home/getMonthSchedules`, async (req, res, ctx) => {
-    const { user_id, date } = await req.json();
-
-    const schedules = getLocalStorage<Schedule[]>(
-      LOCAL_STORAGE_KEY_SCHEDULES,
-      []
-    );
-    const monthSchedules = schedules.filter(
-      (schedule) =>
-        schedule.user_id === user_id &&
-        moment(date).isSame(schedule.start_date, "month")
-    );
-    if (monthSchedules.length === 0) {
-      return res(
-        ctx.delay(1000),
-        ctx.status(200),
-        ctx.json({ data: undefined })
-      );
-    }
-    return res(
-      ctx.delay(1000),
-      ctx.status(200),
-      ctx.json({ data: monthSchedules })
-    );
-  }),
-
   rest.delete(`${DOMAIN}/deleteSchedule`, async (req, res, ctx) => {
     const { schedule_id } = await req.json();
     const prevSchedules = getLocalStorage<Schedule[]>(


### PR DESCRIPTION
mock api 수정을 진행했습니다.

- home/month
> 수정 전
> income: string;
> available: string;
> today_schedules: Schedule[];
> expense: string;

> 수정 후
> income: string;
> available: string;
> data: Schedule[];
> expense: string;
> count: number;

- getMonthSchedules
  - 미사용으로 삭제했습니다.

close #257