### PR TITLE
refactor: 월별 탭 달력 일자 선택 시 자동스크롤 적용

### DIFF
--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -50,7 +50,9 @@ function Home() {
     setValue(newValue);
   };
 
-  const updateHeight = () => swiper?.updateAutoHeight(10);
+  const updateHeight = () => {
+    setTimeout(() => swiper?.updateAutoHeight(10), 100);
+  };
 
   const handleNavigate = () => navigate(PATH.scheduleList);
 
@@ -100,7 +102,7 @@ function Home() {
         onSlideChange={(e) => setValue(e.activeIndex)}
         onSwiper={(swiper) => setSwiper(swiper)}
       >
-        <SwiperSlide style={{ overflow: "scroll" }}>
+        <SwiperSlide>
           <MonthSchedulePage
             updateHeight={updateHeight}
             navigateTo={handleNavigate}

--- a/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
+++ b/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
@@ -23,7 +23,6 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   const [positionY, setPositionY] = useState(-1);
 
   useEffect(() => {
-    window.scrollTo({ top: 0, behavior: "smooth" });
     updateHeight();
   }, [isAtTop]);
 
@@ -33,6 +32,7 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
 
   const handleChangeDate = (newValue: moment.Moment | null) => {
     changeDate(newValue);
+    window.scrollTo({ top: 0, behavior: "smooth" });
     setIsAtTop(false);
   };
 

--- a/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
+++ b/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
@@ -17,13 +17,8 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   const { date, todaySchedules, monthData, isError, isPending, changeDate } =
     useMonthSchedule();
   const calendarRef = useRef<HTMLDivElement>(null);
-  const scheduleListRef = useRef<HTMLDivElement>(null);
   const showPredict = moment().isSameOrBefore(date, "month");
   const isThisMonth = moment().isSame(date, "month");
-  const height =
-    276 +
-    (calendarRef.current?.offsetHeight || 0) +
-    (scheduleListRef.current?.offsetHeight || 0);
   const [isAtTop, setIsAtTop] = useState(true);
   const [positionY, setPositionY] = useState(-1);
 
@@ -37,16 +32,8 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   }, [monthData]);
 
   const handleChangeDate = (newValue: moment.Moment | null) => {
-    // scrollToTop();
     changeDate(newValue);
     setIsAtTop(false);
-  };
-
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 173,
-      behavior: "smooth",
-    });
   };
 
   function handleTouchMove(event: TouchEvent) {
@@ -54,10 +41,8 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
     event.stopPropagation();
     if (positionY < 0) setPositionY(event.touches[0].clientY);
     else if (positionY - event.touches[0].clientY < -30 && !isAtTop) {
-      console.log(positionY - event.touches[0].clientY);
       setIsAtTop(true);
     }
-    // if (!isAtTop) setIsAtTop(true);
   }
 
   if (isPending) {
@@ -102,33 +87,31 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
 
       <ThickDivider />
 
-      <div ref={scheduleListRef}>
-        <ScheduleList
-          date={date}
-          todaySchedules={todaySchedules.slice(0, 3)}
-          isError={isError}
-          isPending={isPending}
-        />
+      <ScheduleList
+        date={date}
+        todaySchedules={todaySchedules.slice(0, 3)}
+        isError={isError}
+        isPending={isPending}
+      />
 
-        {todaySchedules.length > 3 && (
-          <Stack
-            p={2}
-            direction="row"
-            justifyContent="center"
-            alignItems="center"
-            spacing={1.5}
-            onClick={navigateTo}
-          >
-            <Typography>
-              <span style={{ color: "#735BF2", fontWeight: 700 }}>
-                {todaySchedules.length - 3}건
-              </span>
-              &nbsp;일정 더보기
-            </Typography>
-            <KeyboardArrowRightIcon sx={{ color: "#8C919C" }} />
-          </Stack>
-        )}
-      </div>
+      {todaySchedules.length > 3 && (
+        <Stack
+          p={2}
+          direction="row"
+          justifyContent="center"
+          alignItems="center"
+          spacing={1.5}
+          onClick={navigateTo}
+        >
+          <Typography>
+            <span style={{ color: "#735BF2", fontWeight: 700 }}>
+              {todaySchedules.length - 3}건
+            </span>
+            &nbsp;일정 더보기
+          </Typography>
+          <KeyboardArrowRightIcon sx={{ color: "#8C919C" }} />
+        </Stack>
+      )}
     </Box>
   );
 }

--- a/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
+++ b/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
@@ -11,17 +11,36 @@ import ScheduleListSkeleton from "@components/ScheduleList/ScheduleListSkeleton.
 import { Box, Stack, Typography } from "@mui/material";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import { HomePageProps } from "@pages/Home/Home.tsx";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   const { date, todaySchedules, monthData, isError, isPending, changeDate } =
     useMonthSchedule();
+  const calendarRef = useRef<HTMLDivElement>(null);
+  const scheduleListRef = useRef<HTMLDivElement>(null);
   const showPredict = moment().isSameOrBefore(date, "month");
   const isThisMonth = moment().isSame(date, "month");
+  const height =
+    276 +
+    (calendarRef.current?.offsetHeight || 0) +
+    (scheduleListRef.current?.offsetHeight || 0);
 
+  console.log(window.innerHeight - height);
   useEffect(() => {
     updateHeight();
   }, [monthData]);
+
+  const handleChangeDate = (newValue: moment.Moment | null) => {
+    scrollToTop();
+    changeDate(newValue);
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 173,
+      behavior: "smooth",
+    });
+  };
 
   if (isPending) {
     return (
@@ -32,7 +51,7 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
         />
         <ThickDivider />
         <CalendarHeaderSkeleton date={date} />
-        <Calendar value={date} handleChange={changeDate} />
+        <Calendar value={date} handleChange={handleChangeDate} />
         <ThickDivider />
         <ScheduleListSkeleton />
       </Box>
@@ -40,7 +59,13 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   }
 
   return (
-    <Box>
+    <Box
+      pb={
+        window.innerHeight - height > 0
+          ? `${window.innerHeight - height}px`
+          : "0px"
+      }
+    >
       <MonthlyBudgetSummary
         income={parseInt(monthData?.income ?? "")}
         expenditure={parseInt(monthData?.expense ?? "")}
@@ -58,35 +83,39 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
         isToday={moment().isSame(date, "date")}
       />
 
-      <Calendar value={date} handleChange={changeDate} />
+      <div ref={calendarRef}>
+        <Calendar value={date} handleChange={handleChangeDate} />
+      </div>
 
       <ThickDivider />
 
-      <ScheduleList
-        date={date}
-        todaySchedules={todaySchedules.slice(0, 3)}
-        isError={isError}
-        isPending={isPending}
-      />
+      <div ref={scheduleListRef}>
+        <ScheduleList
+          date={date}
+          todaySchedules={todaySchedules.slice(0, 3)}
+          isError={isError}
+          isPending={isPending}
+        />
 
-      {todaySchedules.length > 3 && (
-        <Stack
-          p={2}
-          direction="row"
-          justifyContent="center"
-          alignItems="center"
-          spacing={1.5}
-          onClick={navigateTo}
-        >
-          <Typography>
-            <span style={{ color: "#735BF2", fontWeight: 700 }}>
-              {todaySchedules.length - 3}건
-            </span>
-            &nbsp;일정 더보기
-          </Typography>
-          <KeyboardArrowRightIcon sx={{ color: "#8C919C" }} />
-        </Stack>
-      )}
+        {todaySchedules.length > 3 && (
+          <Stack
+            p={2}
+            direction="row"
+            justifyContent="center"
+            alignItems="center"
+            spacing={1.5}
+            onClick={navigateTo}
+          >
+            <Typography>
+              <span style={{ color: "#735BF2", fontWeight: 700 }}>
+                {todaySchedules.length - 3}건
+              </span>
+              &nbsp;일정 더보기
+            </Typography>
+            <KeyboardArrowRightIcon sx={{ color: "#8C919C" }} />
+          </Stack>
+        )}
+      </div>
     </Box>
   );
 }

--- a/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
+++ b/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
@@ -25,9 +25,12 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
     (calendarRef.current?.offsetHeight || 0) +
     (scheduleListRef.current?.offsetHeight || 0);
 
-  console.log(window.innerHeight - height);
   useEffect(() => {
     updateHeight();
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
   }, [monthData]);
 
   const handleChangeDate = (newValue: moment.Moment | null) => {

--- a/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
+++ b/src/pages/Home/pages/MonthSchedulePage/MonthSchedulePage.tsx
@@ -11,7 +11,7 @@ import ScheduleListSkeleton from "@components/ScheduleList/ScheduleListSkeleton.
 import { Box, Collapse, Stack, Typography } from "@mui/material";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import { HomePageProps } from "@pages/Home/Home.tsx";
-import { TouchEvent, useEffect, useRef, useState } from "react";
+import { TouchEvent, WheelEvent, useEffect, useRef, useState } from "react";
 
 function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   const { date, todaySchedules, monthData, isError, isPending, changeDate } =
@@ -45,6 +45,14 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
     }
   }
 
+  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    if (calendarRef.current?.getBoundingClientRect().top !== 128) return;
+    event.stopPropagation();
+    if (event.deltaY < 0 && !isAtTop) {
+      setIsAtTop(true);
+    }
+  };
+
   if (isPending) {
     return (
       <Box>
@@ -62,7 +70,11 @@ function MonthSchedulePage({ updateHeight, navigateTo }: HomePageProps) {
   }
 
   return (
-    <Box onTouchMove={handleTouchMove} onTouchEnd={() => setPositionY(-1)}>
+    <Box
+      onTouchMove={handleTouchMove}
+      onTouchEnd={() => setPositionY(-1)}
+      onWheel={handleWheel}
+    >
       <Collapse in={isAtTop}>
         <MonthlyBudgetSummary
           income={parseInt(monthData?.income ?? "")}


### PR DESCRIPTION
월별 탭에서 달력의 일자 버튼을 선택 시 상단의 소비/수입 카드를 자동으로 숨기는 기능을 적용했습니다.

첫 시도에는 카드를 숨기기위한 방법으로 자동 스크롤을 사용했습니다. 그러나 자동스크롤을 위해서는 화면의 크기를 맞추기 위한 패딩 값을 계산해서 동적으로 적용해야 했습니다. 그러나 그 계산을 하는 과정에서 일정이 한 개 존재 할 때를 정확히 계산하지 못하는 문제가 있었습니다.

그래서 mui의 collapse를 이용해 카드를 동적으로 숨기고 나타내도록 하는 방식을 적용했습니다.
swiper라이브러리가 collapse가 접히고, 펼져지기 전에 컴포넌트의 크기를 인식하고 자동 높이를 적용하는 문제가 있어 settime함수를 이용해 지연 연산을 적용해 문제를 해결했습니다.

또한, 터치 이벤트와 휠 이벤트를 적용해 모바일 상황에서의 스크롤과 컴퓨터 환경에서의 스크롤을 모두 인식해 동작하도록 적용했습니다.

close #259