### PR TITLE
fix: 배포 오류 해결

### DIFF
--- a/src/pages/AssetManagement/pages/AssetBuCategory/AssetByCategory.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/AssetByCategory.tsx
@@ -9,6 +9,8 @@ import CategoryListItem from "@pages/AssetManagement/pages/AssetBuCategory/compo
 import { setAssetByCategory } from "@app/types/asset.ts";
 import { useState } from "react";
 import { useToast } from "@hooks/toast/useToast.tsx";
+import { IconButton, Typography } from "@mui/material";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 function AssetByCategory() {
   const {
@@ -20,6 +22,8 @@ function AssetByCategory() {
     setAssetByCategory,
     deleteAssetByCategory,
   } = useAssetByCategory();
+  const { openToast, closeToast } = useToast();
+
   const [control, setControl] = useState("");
 
   if (isPending) {
@@ -30,7 +34,29 @@ function AssetByCategory() {
     setAssetByCategory({ ...form, date: yearMonth });
   };
 
-  console.log(assetsByCategory);
+  const compareTotal = (prev: number, curr: number) => {
+    const totalAmount = Number(assetsByCategory?.spend_goal_amount);
+    const totalSummary =
+      assetsByCategory?.category_list.reduce((result, curr) => {
+        return result + Number(curr.category_total);
+      }, 0) ?? 0;
+    console.log(totalSummary - prev + curr, totalAmount);
+
+    if (totalSummary - prev + curr > totalAmount) {
+      openToast({
+        hideDuration: 5000,
+        toastElement: (
+          <Typography flexGrow={1}>지출 목표 금액을 초과했습니다.</Typography>
+        ),
+        color: "primary.main",
+        actionsElement: (
+          <IconButton aria-label="delete" size="small" onClick={closeToast}>
+            <CloseRoundedIcon sx={{ color: "#FFF" }} />
+          </IconButton>
+        ),
+      });
+    }
+  };
 
   return (
     <>
@@ -54,11 +80,11 @@ function AssetByCategory() {
             key={category.name}
             category={category}
             categoryList={categoryList}
-            totalAmount={Number(assetsByCategory?.category_total)}
             control={control}
             setControl={() => setControl(category.name)}
             closeControl={() => setControl("")}
             handleSubmit={handleSubmit}
+            compareTotal={compareTotal}
           />
         );
       })}

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.stories.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.stories.tsx
@@ -26,7 +26,6 @@ const meta = {
       ],
     },
     control: "",
-    totalAmount: 100000000,
     handleSubmit: () => alert("submit"),
   },
   argTypes: {
@@ -49,6 +48,10 @@ const meta = {
     },
     handleSubmit: {
       description: "데이터 수정을 위한 함수입니다.",
+    },
+    compareTotal: {
+      description:
+        "카테고리별 자산 합계를 구해 지출 목표와 비교하는 메서드입니다.",
     },
   },
 } satisfies Meta<typeof CategoryListItem>;

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.stories.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.stories.tsx
@@ -2,10 +2,7 @@ import CategoryListItem, {
   CategoryListItemProps,
 } from "@pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx";
 import { Meta } from "@storybook/react";
-import {
-  EXPENDITURE_CATEGORY,
-  EXPENDITURE_FOOD_CATEGORY,
-} from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/CategoryPicker/constants.ts";
+import { EXPENDITURE_CATEGORY } from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/CategoryPicker/constants.ts";
 
 const meta = {
   title: "AssetManagement/AssetByCategory/CategoryList/CategoryListItem",
@@ -32,7 +29,28 @@ const meta = {
     totalAmount: 100000000,
     handleSubmit: () => alert("submit"),
   },
-  argTypes: {},
+  argTypes: {
+    category: {
+      description:
+        "지출 카테고리를 의미합니다. {name: '카테고리명', subCategory: '세부 카테고리 리스트'} 구조입니다.",
+    },
+    categoryList: {
+      description:
+        "해당 카테고리의 지출 목표 데이터입니다. category_name은 카테고리명을 의미하며, category_total는 해당 카테고리의 총 지출 목표이고 list는 세부 카테고리의 지출 목표 담고 있습니다.",
+    },
+    control: {
+      description: "수정 모드를 on/off 하기 위해 사용되는 매개변수입니다.",
+    },
+    setControl: {
+      description: "수정 모드로 변환합니다.",
+    },
+    closeControl: {
+      description: "수정모드를 제거합니다.",
+    },
+    handleSubmit: {
+      description: "데이터 수정을 위한 함수입니다.",
+    },
+  },
 } satisfies Meta<typeof CategoryListItem>;
 
 export default meta;

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.stories.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.stories.tsx
@@ -2,21 +2,34 @@ import CategoryListItem, {
   CategoryListItemProps,
 } from "@pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx";
 import { Meta } from "@storybook/react";
-import { EXPENDITURE_FOOD_CATEGORY } from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/CategoryPicker/constants.ts";
+import {
+  EXPENDITURE_CATEGORY,
+  EXPENDITURE_FOOD_CATEGORY,
+} from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/CategoryPicker/constants.ts";
 
 const meta = {
   title: "AssetManagement/AssetByCategory/CategoryList/CategoryListItem",
   component: CategoryListItem,
   tags: ["autodocs"],
   args: {
-    category: "음식",
-    subCategories: EXPENDITURE_FOOD_CATEGORY,
-    categoryDetail: [
-      { name: "식비", value: "1000000" },
-      { name: "카페", value: "10000" },
-      { name: "술", value: "?" },
-    ],
-    amount: 100000000,
+    category: EXPENDITURE_CATEGORY[0],
+    categoryList: {
+      category_name: EXPENDITURE_CATEGORY[0].name,
+      category_total: "1010000",
+      list: [
+        { name: "식비", value: "1000000" },
+        {
+          name: "카페",
+          value: "10000",
+        },
+        {
+          name: "술",
+          value: "?",
+        },
+      ],
+    },
+    control: "",
+    totalAmount: 100000000,
     handleSubmit: () => alert("submit"),
   },
   argTypes: {},

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography, Collapse, Button, IconButton } from "@mui/material";
+import { Stack, Typography, Collapse } from "@mui/material";
 import { ChangeEvent, MouseEvent, useEffect, useState } from "react";
 import { AssetByCategory, setAssetByCategory } from "@app/types/asset.ts";
 import ListItemAction from "@pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/components/ListItemAction";
@@ -9,34 +9,31 @@ import {
 } from "@pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryList.styles.ts";
 import { useDialog } from "@hooks/dialog/useDialog.tsx";
 import { getAmount } from "@pages/AssetManagement/utils.ts";
-import { useToast } from "@hooks/toast/useToast.tsx";
-import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 
 export interface CategoryListItemProps {
   category: { name: string; subCategory: string[] };
   categoryList: AssetByCategory;
-  totalAmount: number;
   control: string;
   setControl: () => void;
   closeControl: () => void;
   handleSubmit: (form: Omit<setAssetByCategory, "user_id" | "date">) => void;
+  compareTotal: (prev: number, curr: number) => void;
 }
 
 function CategoryListItem({
   category,
   categoryList,
-  totalAmount,
   control,
   setControl,
   closeControl,
   handleSubmit,
+  compareTotal,
 }: CategoryListItemProps) {
   const [open, setOpen] = useState(false);
   const [total, setTotal] = useState(Number(categoryList.category_total));
   const [form, setForm] = useState(categoryList.list);
 
   const { openConfirm } = useDialog();
-  const { openToast, closeToast } = useToast();
 
   const smallSummary = form.reduce((result, curr) => {
     return result + getAmount(curr.value);
@@ -50,23 +47,10 @@ function CategoryListItem({
 
   useEffect(() => {
     reset();
-  }, [totalAmount]);
+  }, [categoryList.category_total]);
 
   useEffect(() => {
-    if (total > totalAmount) {
-      openToast({
-        hideDuration: 5000,
-        toastElement: (
-          <Typography flexGrow={1}>지출 목표 금액을 초과했습니다.</Typography>
-        ),
-        color: "primary.main",
-        actionsElement: (
-          <IconButton aria-label="delete" size="small" onClick={closeToast}>
-            <CloseRoundedIcon sx={{ color: "#FFF" }} />
-          </IconButton>
-        ),
-      });
-    }
+    compareTotal(Number(categoryList.category_total), total);
   }, [total]);
 
   const reset = () => {


### PR DESCRIPTION
배포 과정에서 build오류를 해결했습니다.

<CategoryListItem> 컴포넌트의 props를 수정하는 과정에서 스토리북의 props 업데이트를 누락해 생긴 오류였습니다.

스토리북 업데이트를 하며 CategoryListItem 스토리북의 props description도 함께 업데이트하였습니다.


추가적으로 카테고리 지출 금액과 지출 목표를 비교해 초과시 토스트 알림을 띄우는 메서드의 결함을 발견하여 해결했습니다.
기존 로직의 경우 카테고리 전체 자산 합계와 수정하는 카테고리의 중분류 합계만을 비교하여 알림을 띄우는 오류가 있었습니다.
따라서 카테고리 전체 자산 합계에 수정중인 카테고리 중분류 합계를 적용하여 지출 목표 금액과 비교한 후 초과한 경우 알림을 띄우도록 수정했습니다.
=> 전체 자산 합계 - 기존 중분류 합계 + 새로운 중분류 합계 > 지출 목표
=> 위와 같은 경우 알림을 띄움
=> 수정하는 과정에서 초과 여부를 바로 알아야하기 때문에 위와 같은 방식을 선택했습니다.

close #269