### PR TITLE
refactor: 정기 템플릿 로직 수정

### DIFF
--- a/src/app/tanstack-query/templates/useTemplateSchedule.ts
+++ b/src/app/tanstack-query/templates/useTemplateSchedule.ts
@@ -73,8 +73,6 @@ export const useTemplateSchedule = () => {
   const importTemplate = async (query: TemplateImportRequest) => {
     const existResponse = await existMutate(query);
 
-    console.log(existResponse);
-
     if (existResponse.template_id === "") return undefined;
 
     const answer = await openConfirm({
@@ -91,8 +89,11 @@ export const useTemplateSchedule = () => {
           template_name: existResponse.template_name,
         }),
       };
+    } else {
+      return {
+        template: { ...existResponse, id: -2 },
+      };
     }
-    return undefined;
   };
 
   return { getTemplate, importTemplate };

--- a/src/app/tanstack-query/templates/useTemplateSchedule.ts
+++ b/src/app/tanstack-query/templates/useTemplateSchedule.ts
@@ -84,10 +84,13 @@ export const useTemplateSchedule = () => {
       rejectText: "아니오",
     });
     if (answer) {
-      return getTemplate({
-        template_id: existResponse.template_id,
-        template_name: existResponse.template_name,
-      });
+      return {
+        template: existResponse,
+        schedule: getTemplate({
+          template_id: existResponse.template_id,
+          template_name: existResponse.template_name,
+        }),
+      };
     }
     return undefined;
   };

--- a/src/app/tanstack-query/templates/useTemplateSchedule.ts
+++ b/src/app/tanstack-query/templates/useTemplateSchedule.ts
@@ -38,6 +38,14 @@ const fetchTemplateExist = async (query: TemplateImportRequest) => {
       },
     }
   ).then<TemplateImportResponse>((res) => {
+    if (!res.ok) {
+      return {
+        template_id: "",
+        template_name: "",
+        category_name: "",
+        user_id: "",
+      };
+    }
     return res.json();
   });
 };
@@ -64,6 +72,10 @@ export const useTemplateSchedule = () => {
 
   const importTemplate = async (query: TemplateImportRequest) => {
     const existResponse = await existMutate(query);
+
+    console.log(existResponse);
+
+    if (existResponse.template_id === "") return undefined;
 
     const answer = await openConfirm({
       title: "알림",

--- a/src/components/ScheduleDrawer/ScheduleDrawer.tsx
+++ b/src/components/ScheduleDrawer/ScheduleDrawer.tsx
@@ -80,6 +80,7 @@ function ScheduleDrawer({ handleClose, resetSchedule }: ScheduleDrawerProps) {
             templates={templates}
             selectedTemplate={selectedTemplate}
             setSelected={setSelected}
+            handleClose={handleClose}
           />
         </SwiperSlide>
         <SwiperSlide>

--- a/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
+++ b/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
@@ -175,12 +175,13 @@ export const useScheduleForm = () => {
     if (result) {
       dispatch(setSelectedTemplate(result.template));
       const schedule = await result.schedule;
-      dispatch(
-        setDrawerScheduleForm({
-          ...SCHEDULE_REQUEST({ ...schedule, schedule_id: undefined }),
-          register_template: true,
-        })
-      );
+      schedule &&
+        dispatch(
+          setDrawerScheduleForm({
+            ...SCHEDULE_REQUEST({ ...schedule, schedule_id: undefined }),
+            register_template: true,
+          })
+        );
     }
   };
 

--- a/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
+++ b/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
@@ -2,6 +2,7 @@ import { UpdateStateInterface } from "@app/types/common.ts";
 import {
   selectScheduleForm,
   setDrawerScheduleForm,
+  setSelectedTemplate,
 } from "@redux/slices/scheduleSlice.tsx";
 import moment from "moment/moment";
 import {
@@ -172,9 +173,11 @@ export const useScheduleForm = () => {
       event_name: eventName,
     });
     if (result) {
+      dispatch(setSelectedTemplate(result.template));
+      const schedule = await result.schedule;
       dispatch(
         setDrawerScheduleForm({
-          ...SCHEDULE_REQUEST({ ...result, schedule_id: undefined }),
+          ...SCHEDULE_REQUEST({ ...schedule, schedule_id: undefined }),
           register_template: true,
         })
       );

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
@@ -2,6 +2,7 @@ import { useAppSelector } from "@redux/hooks.ts";
 import {
   selectDate,
   selectScheduleForm,
+  selectSelectedTemplate,
 } from "@redux/slices/scheduleSlice.tsx";
 import { SCHEDULE_DRAWER } from "@constants/schedule.ts";
 import useSchedule from "@hooks/schedule/useSchedule.ts";
@@ -26,6 +27,7 @@ function CreateFooter({
   const date = useAppSelector(selectDate);
   const schedule = useAppSelector(selectScheduleForm);
   const guestMode = useAppSelector(selectGuestMode);
+  const template = useAppSelector(selectSelectedTemplate);
   const { data: user } = useUser();
   const { handleCreateSchedule } = useSchedule();
   const { setRandomGeneratedSchedule } = useScheduleForm();
@@ -34,7 +36,13 @@ function CreateFooter({
   const handleCreate = async () => {
     if (!handleSubmit() || !schedule) return;
 
-    if (schedule.repeat.kind_type !== "none" && !schedule.register_template) {
+    console.log(template);
+
+    if (
+      schedule.repeat.kind_type !== "none" &&
+      !schedule.register_template &&
+      template.id === -1
+    ) {
       const answer = await openConfirm({
         title: "알림",
         content: "반복 일정을 정기템플릿에\n등록하시겠습니까?",

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
@@ -38,11 +38,7 @@ function CreateFooter({
 
     console.log(template);
 
-    if (
-      schedule.repeat.kind_type !== "none" &&
-      !schedule.register_template &&
-      template.id === -1
-    ) {
+    if (schedule.repeat.kind_type !== "none" && template.id === -1) {
       const answer = await openConfirm({
         title: "알림",
         content: "반복 일정을 정기템플릿에\n등록하시겠습니까?",
@@ -62,7 +58,7 @@ function CreateFooter({
         rejectText: "아니오",
       });
       if (answer) {
-        await handleCreateSchedule(schedule);
+        await handleCreateSchedule({ ...schedule, register_template: false });
         handleClose();
       }
     }

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/ScheduleFormPage.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/ScheduleFormPage.tsx
@@ -13,6 +13,7 @@ export interface ScheduleFormPageProps extends ScheduleFormProps {
   showError: boolean;
   setIsCategoryPickerOpen: Dispatch<SetStateAction<boolean>>;
   setIsRepeatPickerOpen: Dispatch<SetStateAction<boolean>>;
+  handleClose: () => void;
 }
 
 function ScheduleFormPage({
@@ -22,6 +23,7 @@ function ScheduleFormPage({
   templates,
   setSelected,
   selectedTemplate,
+  handleClose,
 }: ScheduleFormPageProps) {
   const { scheduleForm, getRepeat } = useScheduleForm();
 
@@ -44,6 +46,7 @@ function ScheduleFormPage({
               templates={templates}
               selectedTemplate={selectedTemplate}
               setSelected={setSelected}
+              handleClose={handleClose}
             />
           )}
         </Stack>

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/SelectTemplate/SelectTemplate.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/SelectTemplate/SelectTemplate.tsx
@@ -8,12 +8,14 @@ export interface ScheduleFormProps {
   templates?: Template[];
   selectedTemplate: Template;
   setSelected: (template: Template) => void;
+  handleClose: () => void;
 }
 
 function SelectTemplate({
   templates,
   selectedTemplate,
   setSelected,
+  handleClose,
 }: ScheduleFormProps) {
   const { openDrawer } = useTemplateDrawer();
 
@@ -32,7 +34,7 @@ function SelectTemplate({
             fontSize="12px"
             fontWeight={600}
             color="#0075FF"
-            onClick={() => openDrawer(setSelected)}
+            onClick={() => openDrawer(setSelected, handleClose)}
           >
             {SCHEDULE_DRAWER.showAllTemplate}
           </Typography>

--- a/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/SelectTemplate/components/TemplateList/TemplateList.tsx
+++ b/src/components/ScheduleDrawer/pages/ScheduleFormPage/components/SelectTemplate/components/TemplateList/TemplateList.tsx
@@ -3,7 +3,6 @@ import {
   TemplateBadge,
   TemplateListContainer,
 } from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/SelectTemplate/components/TemplateList/TemplateList.styles.ts";
-import { Stack } from "@mui/material";
 import { Template } from "@app/types/template.ts";
 import TemplateIconSVG from "@components/common/TemplateIconSVG";
 
@@ -15,7 +14,11 @@ export interface TemplateListProps {
 
 function TemplateList({ templates, selected, setSelected }: TemplateListProps) {
   if (!templates || templates.length === 0)
-    return <EmptyTemplateBadge>기록된 일정이 없어요</EmptyTemplateBadge>;
+    return (
+      <TemplateListContainer>
+        <EmptyTemplateBadge>기록된 일정이 없어요</EmptyTemplateBadge>
+      </TemplateListContainer>
+    );
 
   return (
     <TemplateListContainer>

--- a/src/components/TemplateDrawer/TemplateDrawer.tsx
+++ b/src/components/TemplateDrawer/TemplateDrawer.tsx
@@ -12,6 +12,7 @@ import useAsset from "@hooks/assetManagement/useAsset.ts";
 export interface TemplateDrawerProps {
   closeDrawer: () => void;
   setSelected: (t: Template) => void;
+  handleClose: () => void;
 }
 
 export interface TemplatePageProps {
@@ -21,7 +22,11 @@ export interface TemplatePageProps {
   deleteTemplate?: (t: number[]) => void;
 }
 
-function TemplateDrawer({ closeDrawer, setSelected }: TemplateDrawerProps) {
+function TemplateDrawer({
+  closeDrawer,
+  setSelected,
+  handleClose,
+}: TemplateDrawerProps) {
   const [isModify, setIsModify] = useState(false);
   const { spendSchedules, saveSchedules, handleDelete } = useRegularAsset();
   const { openConfirm } = useDialog();
@@ -43,6 +48,7 @@ function TemplateDrawer({ closeDrawer, setSelected }: TemplateDrawerProps) {
   const handleModify = (v: string) => {
     if (v === "관리") {
       closeDrawer();
+      handleClose();
       setMenu(3, false);
     } else {
       setIsModify(true);

--- a/src/components/TemplateDrawer/TemplateDrawer.tsx
+++ b/src/components/TemplateDrawer/TemplateDrawer.tsx
@@ -43,7 +43,7 @@ function TemplateDrawer({ closeDrawer, setSelected }: TemplateDrawerProps) {
   const handleModify = (v: string) => {
     if (v === "관리") {
       closeDrawer();
-      setMenu(3);
+      setMenu(3, false);
     } else {
       setIsModify(true);
     }

--- a/src/hooks/assetManagement/useAsset.ts
+++ b/src/hooks/assetManagement/useAsset.ts
@@ -8,9 +8,9 @@ const useAsset = () => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  const setMenu = (menu: number) => {
+  const setMenu = (menu: number, replace = true) => {
     dispatch(setAssetMenu(menu));
-    navigate(assetManagements[menu].path, { replace: true });
+    navigate(assetManagements[menu].path, { replace: replace });
   };
 
   return {

--- a/src/hooks/dialog/Dialog.tsx
+++ b/src/hooks/dialog/Dialog.tsx
@@ -38,7 +38,12 @@ function Dialog({
           </Typography>
         </Stack>
         <Divider sx={{ backgroundColor: "black", height: "1px" }} />
-        <Typography variant="h2" textAlign="center" whiteSpace="pre-line">
+        <Typography
+          variant="h2"
+          textAlign="center"
+          whiteSpace="pre-line"
+          sx={{ wordBreak: "keep-all" }}
+        >
           {content}
         </Typography>
         <Typography

--- a/src/hooks/useTemplateDrawer.tsx
+++ b/src/hooks/useTemplateDrawer.tsx
@@ -6,7 +6,10 @@ import { Template } from "@app/types/template.ts";
 export const useTemplateDrawer = () => {
   const { openOverlay, closeOverlay } = useOverlay();
 
-  const openDrawer = (setSelected: (t: Template) => void) => {
+  const openDrawer = (
+    setSelected: (t: Template) => void,
+    handleClose: () => void
+  ) => {
     openOverlay(
       <Drawer
         open={true}
@@ -20,7 +23,11 @@ export const useTemplateDrawer = () => {
           },
         }}
       >
-        <TemplateDrawer closeDrawer={closeOverlay} setSelected={setSelected} />
+        <TemplateDrawer
+          closeDrawer={closeOverlay}
+          setSelected={setSelected}
+          handleClose={handleClose}
+        />
       </Drawer>
     );
   };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -36,11 +36,9 @@ import {
   ModifyTemplateRequest,
   ModifyTemplateSchedulesRequest,
   Template,
-  TemplateImportRequest,
   TemplateScheduleRequest,
   TemplateSchedulesRequest,
 } from "@app/types/template.ts";
-import { object } from "prop-types";
 
 const getSign = (type: string) => (type === "Plus" ? "+" : "-");
 
@@ -746,7 +744,7 @@ export const handlers = [
       );
       const template = templates.find((t) => t.id === Number(template_id));
 
-      if (!template) return HttpResponse.json({ status: 400 });
+      if (!template) return HttpResponse.json(null, { status: 400 });
 
       const schedules = getLocalStorage<Schedule[]>(
         LOCAL_STORAGE_KEY_SCHEDULES,
@@ -765,7 +763,6 @@ export const handlers = [
 
   http.get(`${DOMAIN}/template/import`, async ({ request }) => {
     const url = new URL(request.url);
-    const user_id = url.searchParams.get("userId");
     const category_name = url.searchParams.get("category_name");
     const event_name = url.searchParams.get("event_name");
     await delay(1000);
@@ -837,10 +834,10 @@ export const handlers = [
 
   http.get<TemplateSchedulesRequest>(
     `${DOMAIN}/asset/template/schedule/info`,
-    async ({ params, request }) => {
-      const id = request.url.split("template_id=")[1];
+    async ({ request }) => {
+      const url = new URL(request.url);
+      const template_id = url.searchParams.get("template_id");
       await delay(1000);
-      const { user_id, template_id } = params; // params가 빈 obj로 나오는 오류의 원인을 찾아야 할 듯
       const templates = getLocalStorage<Template[]>(
         LOCAL_STORAGE_KEY_TEMPLATE,
         []
@@ -850,7 +847,7 @@ export const handlers = [
         []
       );
 
-      const template = templates.find((t) => t.id === Number(id));
+      const template = templates.find((t) => t.id === Number(template_id));
 
       return HttpResponse.json(
         {

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -40,6 +40,7 @@ import {
   TemplateScheduleRequest,
   TemplateSchedulesRequest,
 } from "@app/types/template.ts";
+import { object } from "prop-types";
 
 const getSign = (type: string) => (type === "Plus" ? "+" : "-");
 
@@ -762,32 +763,31 @@ export const handlers = [
     }
   ),
 
-  http.get<TemplateImportRequest>(
-    `${DOMAIN}/template/import`,
-    async ({ params }) => {
-      await delay(1000);
-      const { user_id, category_name, event_name } = params;
-      const templates = getLocalStorage<Template[]>(
-        LOCAL_STORAGE_KEY_TEMPLATE,
-        []
-      );
-      const template = templates.find(
-        (t) =>
-          t.category_name === category_name &&
-          t.template_name === event_name &&
-          t.user_id === user_id
-      );
-      if (!template) return HttpResponse.json({ status: 400 });
+  http.get(`${DOMAIN}/template/import`, async ({ request }) => {
+    const url = new URL(request.url);
+    const user_id = url.searchParams.get("userId");
+    const category_name = url.searchParams.get("category_name");
+    const event_name = url.searchParams.get("event_name");
+    await delay(1000);
+    console.log(category_name, event_name);
+    const templates = getLocalStorage<Template[]>(
+      LOCAL_STORAGE_KEY_TEMPLATE,
+      []
+    );
+    const template = templates.find(
+      (t) => t.category_name === category_name && t.template_name === event_name
+    );
+    console.log(template);
+    if (!template) return HttpResponse.json(null, { status: 400 });
 
-      return HttpResponse.json(
-        {
-          ...template,
-          template_id: template.id,
-        },
-        { status: 200 }
-      );
-    }
-  ),
+    return HttpResponse.json(
+      {
+        ...template,
+        template_id: template.id,
+      },
+      { status: 200 }
+    );
+  }),
 
   http.post(`${DOMAIN}/template/details`, async () => {
     await delay(1000);

--- a/src/pages/AssetManagement/components/SettingsPaper/SettingCard.tsx
+++ b/src/pages/AssetManagement/components/SettingsPaper/SettingCard.tsx
@@ -16,7 +16,7 @@ function SettingCard({ setting, index }: SettingCardProps) {
       direction="row"
       justifyContent="space-between"
       alignItems="center"
-      onClick={() => setMenu(index)}
+      onClick={() => setMenu(index, false)}
       py={2}
       pr={1.5}
     >

--- a/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.styles.ts
+++ b/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.styles.ts
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+export const ModifyInfoContainer = styled.div`
+  padding: 4px 0;
+  margin-top: 14px;
+  text-align: center;
+  color: #0075ff;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 22px; /* 157.143% */
+  letter-spacing: 0.4px;
+`;

--- a/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
+++ b/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
@@ -7,6 +7,7 @@ import FormContainer from "@pages/AssetManagement/pages/RegularAsset/pages/Modif
 import { useModifyTemplate } from "@app/tanstack-query/templates/useModifyTemplate.ts";
 import { useScheduleDrawer } from "@hooks/useScheduleDrawer.tsx";
 import { Template } from "@app/types/template.ts";
+import { ModifyInfoContainer } from "@pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.styles.ts";
 
 export interface ModifyTemplateProps extends ModifyRegularAssetsProps {
   template: Omit<Template, "amount">;
@@ -58,6 +59,10 @@ function ModifyTemplate({ closeDrawer, template }: ModifyTemplateProps) {
         handleChange={handleChange}
         handleClick={handleClickCategory}
       />
+
+      <ModifyInfoContainer>
+        정기 템플릿 수정 시, 포함된 일정의 정보가 모두 변경됩니다.
+      </ModifyInfoContainer>
 
       <ModifyContainer>
         <Button fullWidth onClick={handleSubmit}>

--- a/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
+++ b/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
@@ -8,6 +8,7 @@ import { useModifyTemplate } from "@app/tanstack-query/templates/useModifyTempla
 import { useScheduleDrawer } from "@hooks/useScheduleDrawer.tsx";
 import { Template } from "@app/types/template.ts";
 import { ModifyInfoContainer } from "@pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.styles.ts";
+import { useDialog } from "@hooks/dialog/useDialog.tsx";
 
 export interface ModifyTemplateProps extends ModifyRegularAssetsProps {
   template: Omit<Template, "amount">;
@@ -15,6 +16,7 @@ export interface ModifyTemplateProps extends ModifyRegularAssetsProps {
 
 function ModifyTemplate({ closeDrawer, template }: ModifyTemplateProps) {
   const { modifyTemplate } = useModifyTemplate();
+  const { openConfirm } = useDialog();
   const [eventName, setEventName] = useState(template.template_name);
   const [categoryName, setCategoryName] = useState(template.category_name);
   const { openCategoryDrawer } = useScheduleDrawer();
@@ -29,13 +31,21 @@ function ModifyTemplate({ closeDrawer, template }: ModifyTemplateProps) {
   };
 
   const handleSubmit = async () => {
-    await modifyTemplate({
-      user_id: template.user_id,
-      event_name: eventName,
-      category_name: categoryName,
-      template_id: template.id.toString(),
+    const answer = await openConfirm({
+      title: "알림",
+      content: "정기 템플릿의 정보를 일괄 수정합니다.",
+      approveText: "확인",
+      rejectText: "취소",
     });
-    closeDrawer();
+    if (answer) {
+      await modifyTemplate({
+        user_id: template.user_id,
+        event_name: eventName,
+        category_name: categoryName,
+        template_id: template.id.toString(),
+      });
+      closeDrawer();
+    }
   };
 
   return (


### PR DESCRIPTION
정기 템플릿 로직을 수정했습니다.

- 자산관리 페이지로 이동할 때 replace가 자동 적용되는 문제를 해결했습니다.
  - 자산관리 세부 메뉴에서 이동할 때만 replace가 적용되고 그 외의 경우에는 적용되지 않도록 수정했습니다.
- ScheduleDrawer에서 자산관리 페이지로 넘어갈 때 ScheduleDrawer가 내려가도록 수정했습니다.
- 템플릿 중복 확인 로직을 구현했습니다.
  - 템플릿 중복 확인 후 중복일 경우 템플릿 적용 확인 모달 띄웁니다.
- 일정을 추가할 때 템플릿 추가 모달을 띄우는 조건을 수정했습니다.
  - 기존은 반복일정이면서 선택한 템플릿이 없을 때
- 정기 템플릿 전체 수정 페이지에 안내 문구를 추가했습니다.
- 정기 템플릿 전체 수정 시 확인 모달을 추가했습니다.

close #306