### PR TITLE
refactor: 정기 템플릿 api 연동 확인

### DIFF
--- a/src/app/tanstack-query/templates/useDeleteTemplate.ts
+++ b/src/app/tanstack-query/templates/useDeleteTemplate.ts
@@ -2,17 +2,22 @@ import { getSessionStorage } from "@utils/storage.ts";
 import { SESSION_STORAGE_KEY_TOKEN } from "@api/keys.ts";
 import { DOMAIN } from "@api/url.ts";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { QUERY_KEY_TEMPLATE_BY_PRICE_TYPE } from "@constants/queryKeys.ts";
+import {
+  QUERY_KEY_SCHEDULES,
+  QUERY_KEY_TEMPLATE,
+} from "@constants/queryKeys.ts";
 
-const fetchDeleteTemplate = async (ids: string[]) => {
+const fetchDeleteTemplate = async (templates: number[]) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
 
+  const ids = templates.map((template) => `template_ids=${template}`);
   return fetch(`${DOMAIN}/asset/template/delete?${ids.join("&")}`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
       Authorization: "Bearer " + token,
     },
+    body: JSON.stringify({ template_ids: templates }),
   });
 };
 
@@ -22,13 +27,16 @@ export const useDeleteTemplate = () => {
     mutationFn: fetchDeleteTemplate,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEY_TEMPLATE_BY_PRICE_TYPE],
+        queryKey: [QUERY_KEY_TEMPLATE],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY_SCHEDULES],
       });
     },
   });
 
   const deleteTemplate = async (templates: number[]) => {
-    mutate(templates.map((template) => `template_ids=${template}`));
+    mutate(templates);
   };
 
   return { deleteTemplate };

--- a/src/app/tanstack-query/templates/useDeleteTemplate.ts
+++ b/src/app/tanstack-query/templates/useDeleteTemplate.ts
@@ -2,18 +2,17 @@ import { getSessionStorage } from "@utils/storage.ts";
 import { SESSION_STORAGE_KEY_TOKEN } from "@api/keys.ts";
 import { DOMAIN } from "@api/url.ts";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { QUERY_KEY_TEMPLATE } from "@constants/queryKeys.ts";
+import { QUERY_KEY_TEMPLATE_BY_PRICE_TYPE } from "@constants/queryKeys.ts";
 
-const fetchDeleteTemplate = async (id: string) => {
+const fetchDeleteTemplate = async (ids: string[]) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
 
-  return fetch(`${DOMAIN}/asset/template/delete`, {
+  return fetch(`${DOMAIN}/asset/template/delete?${ids.join("&")}`, {
     method: "DELETE",
     headers: {
       "Content-Type": "application/json",
       Authorization: "Bearer " + token,
     },
-    body: JSON.stringify({ template_id: id }),
   });
 };
 
@@ -23,15 +22,13 @@ export const useDeleteTemplate = () => {
     mutationFn: fetchDeleteTemplate,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEY_TEMPLATE],
+        queryKey: [QUERY_KEY_TEMPLATE_BY_PRICE_TYPE],
       });
     },
   });
 
   const deleteTemplate = async (templates: number[]) => {
-    templates.forEach((template) => {
-      mutate(template.toString());
-    });
+    mutate(templates.map((template) => `template_ids=${template}`));
   };
 
   return { deleteTemplate };

--- a/src/app/tanstack-query/templates/useTemplateByPriceType.ts
+++ b/src/app/tanstack-query/templates/useTemplateByPriceType.ts
@@ -8,13 +8,12 @@ import { TemplateByPriceType, TemplateRequest } from "@app/types/template.ts";
 const fetchTemplates = async (query: TemplateRequest) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
 
-  return fetch(`${DOMAIN}/asset/template/view`, {
-    method: "POST",
+  return fetch(`${DOMAIN}/asset/template/view?user_id=${query.user_id}`, {
+    method: "GET",
     headers: {
       "Content-Type": "application/json",
       Authorization: "Bearer " + token,
     },
-    body: JSON.stringify(query),
   }).then<TemplateByPriceType>(async (res) => {
     if (!res.ok) {
       return [];

--- a/src/app/tanstack-query/templates/useTemplateByPriceType.ts
+++ b/src/app/tanstack-query/templates/useTemplateByPriceType.ts
@@ -1,7 +1,10 @@
 import { SESSION_STORAGE_KEY_TOKEN } from "@api/keys.ts";
 import { DOMAIN } from "@api/url.ts";
 import { getSessionStorage } from "@utils/storage.ts";
-import { QUERY_KEY_TEMPLATE_BY_PRICE_TYPE } from "@constants/queryKeys.ts";
+import {
+  QUERY_KEY_TEMPLATE,
+  QUERY_KEY_TEMPLATE_BY_PRICE_TYPE,
+} from "@constants/queryKeys.ts";
 import { useQuery } from "@tanstack/react-query";
 import { TemplateByPriceType, TemplateRequest } from "@app/types/template.ts";
 
@@ -24,7 +27,7 @@ const fetchTemplates = async (query: TemplateRequest) => {
 
 export const useTemplateByPriceType = (query: TemplateRequest) => {
   return useQuery({
-    queryKey: [QUERY_KEY_TEMPLATE_BY_PRICE_TYPE],
+    queryKey: [QUERY_KEY_TEMPLATE, QUERY_KEY_TEMPLATE_BY_PRICE_TYPE],
     queryFn: () => fetchTemplates(query),
   });
 };

--- a/src/app/tanstack-query/templates/useTemplateSchedule.ts
+++ b/src/app/tanstack-query/templates/useTemplateSchedule.ts
@@ -13,14 +13,17 @@ import { useDialog } from "@hooks/dialog/useDialog.tsx";
 const fetchTemplateSchedule = async (query: TemplateScheduleRequest) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
 
-  return fetch(`${DOMAIN}/createSchedule/template`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: "Bearer " + token,
-    },
-    body: JSON.stringify(query),
-  }).then<Schedule>((res) => {
+  return fetch(
+    `${DOMAIN}/createSchedule/template?template_id=${query.template_id}&template_name=${query.template_name}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + token,
+      },
+      body: JSON.stringify(query),
+    }
+  ).then<Schedule>((res) => {
     return res.json();
   });
 };

--- a/src/app/tanstack-query/templates/useTemplateSchedule.ts
+++ b/src/app/tanstack-query/templates/useTemplateSchedule.ts
@@ -32,7 +32,7 @@ const fetchTemplateExist = async (query: TemplateImportRequest) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
 
   return fetch(
-    `${DOMAIN}/template/import?userId=${query.user_id}&category_name=${query.category_name}&event_name=${query.event_name}`,
+    `${DOMAIN}/template/is_exists?userId=${query.user_id}&category_name=${query.category_name}&event_name=${query.event_name}`,
     {
       method: "GET",
       headers: {
@@ -43,10 +43,12 @@ const fetchTemplateExist = async (query: TemplateImportRequest) => {
   ).then<TemplateImportResponse>((res) => {
     if (!res.ok) {
       return {
-        template_id: "",
-        template_name: "",
-        category_name: "",
-        user_id: "",
+        template_data: {
+          template_id: "",
+          template_name: "",
+          category_name: "",
+          user_id: "",
+        },
       };
     }
     return res.json();
@@ -54,7 +56,6 @@ const fetchTemplateExist = async (query: TemplateImportRequest) => {
 };
 
 export const useTemplateSchedule = () => {
-  const { openConfirm } = useDialog();
   const { mutateAsync } = useMutation<Schedule, Error, TemplateScheduleRequest>(
     {
       mutationFn: fetchTemplateSchedule,
@@ -74,29 +75,7 @@ export const useTemplateSchedule = () => {
   };
 
   const importTemplate = async (query: TemplateImportRequest) => {
-    const existResponse = await existMutate(query);
-
-    if (existResponse.template_id === "") return undefined;
-
-    const answer = await openConfirm({
-      title: "알림",
-      content: `동일한 정기 템플릿이 존재합니다.\n템플릿에 일정을 추가하시겠습니까?\n\n{${query.category_name}}\n{${query.event_name}}`,
-      approveText: "네",
-      rejectText: "아니오",
-    });
-    if (answer) {
-      return {
-        template: existResponse,
-        schedule: getTemplate({
-          template_id: existResponse.template_id,
-          template_name: existResponse.template_name,
-        }),
-      };
-    } else {
-      return {
-        template: { ...existResponse, id: -2 },
-      };
-    }
+    return await existMutate(query);
   };
 
   return { getTemplate, importTemplate };

--- a/src/app/tanstack-query/templates/useTemplates.ts
+++ b/src/app/tanstack-query/templates/useTemplates.ts
@@ -8,13 +8,12 @@ import { Template, TemplateRequest } from "@app/types/template.ts";
 const fetchTemplates = async (query: TemplateRequest) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
 
-  return fetch(`${DOMAIN}/template/details`, {
-    method: "POST",
+  return fetch(`${DOMAIN}/template/details?user_id=${query.user_id}`, {
+    method: "GET",
     headers: {
       "Content-Type": "application/json",
       Authorization: "Bearer " + token,
     },
-    body: JSON.stringify(query),
   }).then<Template[]>(async (res) => {
     if (!res.ok) {
       return [];

--- a/src/app/types/template.ts
+++ b/src/app/types/template.ts
@@ -23,11 +23,16 @@ export interface TemplateImportRequest extends TemplateRequest {
   event_name: string;
 }
 
-export interface TemplateImportResponse {
+export interface TemplateImport {
   template_id: string;
   user_id: string;
   template_name: string;
   category_name: string;
+}
+
+export interface TemplateImportResponse {
+  schedule_data?: Schedule;
+  template_data: TemplateImport;
 }
 
 export interface TemplateByPriceType {

--- a/src/app/types/template.ts
+++ b/src/app/types/template.ts
@@ -62,6 +62,9 @@ export interface ModifyTemplateSchedulesRequest
   schedule_id_list: string;
 }
 
-export interface ModifyTemplateRequest extends TemplateImportRequest {
+export interface ModifyTemplateRequest {
   template_id: string;
+  user_id: string;
+  template_name: string;
+  category_name: string;
 }

--- a/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
+++ b/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
@@ -203,7 +203,7 @@ export const useScheduleForm = () => {
       dispatch(
         setSelectedTemplate({
           ...template,
-          id: "-2",
+          id: -1,
         })
       );
     }

--- a/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
+++ b/src/components/ScheduleDrawer/hooks/useScheduleForm.ts
@@ -203,7 +203,7 @@ export const useScheduleForm = () => {
       dispatch(
         setSelectedTemplate({
           ...template,
-          id: -1,
+          id: -2,
         })
       );
     }

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
@@ -37,19 +37,25 @@ function CreateFooter({
     if (!handleSubmit() || !schedule) return;
 
     if (schedule.repeat.kind_type !== "none" && template.id === -1) {
-      const answer = await openConfirm({
-        title: "알림",
-        content: "반복 일정을 정기템플릿에\n등록하시겠습니까?",
-        subContent: `남은 정기템플릿 : ${templateCount}/10`,
-        approveText: "네",
-        rejectText: "아니오",
-      });
-      if (answer) {
-        await handleCreateSchedule({ ...schedule, register_template: true });
-        handleClose();
-      } else {
-        await handleCreateSchedule({ ...schedule, register_template: false });
-        handleClose();
+      if (templateCount > 10) {
+        const answer = await openConfirm({
+          title: "알림",
+          content:
+            templateCount > 10
+              ? "정기템플릿을 모두 사용했어요.\n정기템플릿을 추가하시겠습니까?"
+              : "반복 일정을 정기템플릿에\n등록하시겠습니까?",
+          subContent:
+            templateCount > 10 ? "" : `남은 정기템플릿 : ${templateCount}/10`,
+          approveText: "네",
+          rejectText: "아니오",
+        });
+        if (answer) {
+          await handleCreateSchedule({ ...schedule, register_template: true });
+          handleClose();
+        } else {
+          await handleCreateSchedule({ ...schedule, register_template: false });
+          handleClose();
+        }
       }
     } else {
       const answer = await openConfirm({

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
@@ -19,6 +19,8 @@ interface CreateFooterInterface {
   templateCount: number;
 }
 
+const MAX_TEMPLATE_COUNT = 10;
+
 function CreateFooter({
   handleSubmit,
   handleClose,
@@ -37,15 +39,17 @@ function CreateFooter({
     if (!handleSubmit() || !schedule) return;
 
     if (schedule.repeat.kind_type !== "none" && template.id === -1) {
-      if (templateCount > 10) {
+      if (templateCount > MAX_TEMPLATE_COUNT) {
         const answer = await openConfirm({
           title: "알림",
           content:
-            templateCount > 10
+            templateCount > MAX_TEMPLATE_COUNT
               ? "정기템플릿을 모두 사용했어요.\n정기템플릿을 추가하시겠습니까?"
               : "반복 일정을 정기템플릿에\n등록하시겠습니까?",
           subContent:
-            templateCount > 10 ? "" : `남은 정기템플릿 : ${templateCount}/10`,
+            templateCount > MAX_TEMPLATE_COUNT
+              ? ""
+              : `남은 정기템플릿 : ${templateCount}/10`,
           approveText: "네",
           rejectText: "아니오",
         });

--- a/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
+++ b/src/components/ScheduleDrawer/layouts/ScheduleDrawerFooter/CreateFooter.tsx
@@ -36,8 +36,6 @@ function CreateFooter({
   const handleCreate = async () => {
     if (!handleSubmit() || !schedule) return;
 
-    console.log(template);
-
     if (schedule.repeat.kind_type !== "none" && template.id === -1) {
       const answer = await openConfirm({
         title: "알림",
@@ -48,6 +46,9 @@ function CreateFooter({
       });
       if (answer) {
         await handleCreateSchedule({ ...schedule, register_template: true });
+        handleClose();
+      } else {
+        await handleCreateSchedule({ ...schedule, register_template: false });
         handleClose();
       }
     } else {

--- a/src/components/ScheduleList/constants.ts
+++ b/src/components/ScheduleList/constants.ts
@@ -1,6 +1,6 @@
 export const CATEGORY_ICONS: { [key: string]: string } = {
   급여: "salary",
-  용돈: "pin_money",
+  용돈: "pin-money",
   대출금: "loan",
   금융수입: "financial-income",
   사업수입: "corporate-income",

--- a/src/hooks/assetManagement/RegularTemplate/useRegularAssetDrawer.tsx
+++ b/src/hooks/assetManagement/RegularTemplate/useRegularAssetDrawer.tsx
@@ -2,6 +2,7 @@ import { useOverlay } from "@hooks/use-overlay/useOverlay.tsx";
 import ModifyRegularAssets from "@pages/AssetManagement/pages/RegularAsset/pages/ModifyRegularAssets";
 import ModifyTemplate from "@pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate";
 import { Template } from "@app/types/template.ts";
+import React from "react";
 
 export const useRegularAssetDrawer = () => {
   const { openOverlay, closeOverlay } = useOverlay();

--- a/src/hooks/schedule/useSchedule.ts
+++ b/src/hooks/schedule/useSchedule.ts
@@ -44,6 +44,7 @@ const useSchedule = () => {
       schedule_id: uuidv4(),
       user_id: user.user_id,
     };
+    console.log(scheduleWithUuid);
 
     createSchedule(scheduleWithUuid);
     resetSchedule();

--- a/src/hooks/schedule/useScheduleTemplate.ts
+++ b/src/hooks/schedule/useScheduleTemplate.ts
@@ -27,6 +27,7 @@ const useScheduleTemplate = () => {
 
   const lastTemplates =
     templates?.filter((t) => t.id !== selectedTemplate?.id) ?? [];
+
   const templateCount = templates?.length ?? 0;
 
   const setSelected = async (t: Template) => {

--- a/src/hooks/toast/useToast.tsx
+++ b/src/hooks/toast/useToast.tsx
@@ -16,6 +16,7 @@ export const useToast = () => {
     toastElement: ReactNode;
     actionsElement?: ReactNode;
   }) => {
+    console.log(color);
     openOverlay(
       <Toast
         hideDuration={hideDuration}

--- a/src/hooks/useScheduleDrawer.tsx
+++ b/src/hooks/useScheduleDrawer.tsx
@@ -11,11 +11,29 @@ import ScheduleAssetDrawer from "@components/ScheduleDrawer/ScheduleAssetDrawer.
 import { getPriceTypeSign } from "@components/ScheduleDrawer/hooks/useScheduleForm.ts";
 import { ModifyTemplateSchedule } from "@app/types/template.ts";
 import CategoryPicker from "@components/ScheduleDrawer/pages/ScheduleFormPage/components/CategoryPicker";
+import { useToast } from "@hooks/toast/useToast.tsx";
+import { Stack, Typography } from "@mui/material";
+import CancelRoundedIcon from "@mui/icons-material/CancelRounded";
+import React from "react";
 
 export const useScheduleDrawer = () => {
   const { openDrawer, closeDrawer } = useSwipeableDrawer();
   const dispatch = useAppDispatch();
   const schedule = useAppSelector(selectScheduleForm);
+  const { openToast, closeToast } = useToast();
+
+  const handleClickToastOpen = () => {
+    openToast({
+      hideDuration: 5000,
+      toastElement: (
+        <Stack direction={"row"} spacing={1} alignItems={"center"} p={1}>
+          <CancelRoundedIcon color={"error"} />
+          <Typography flexGrow={1}>자산 정보만 수정이 가능해요!</Typography>
+        </Stack>
+      ),
+      color: "#36383D",
+    });
+  };
 
   const openScheduleDrawer = (data: RequestSchedule) => {
     if (schedule?.schedule_id !== data.schedule_id)
@@ -41,6 +59,8 @@ export const useScheduleDrawer = () => {
     const schedule = { ...data, price_type: getPriceTypeSign(data.price_type) };
     dispatch(setDrawerScheduleForm(schedule));
     const resetSchedule = () => dispatch(setDrawerScheduleForm(schedule));
+
+    handleClickToastOpen();
 
     openDrawer(
       <ScheduleAssetDrawer

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -800,7 +800,7 @@ export const handlers = [
     );
   }),
 
-  http.post(`${DOMAIN}/asset/template/view`, async () => {
+  http.get(`${DOMAIN}/asset/template/view`, async () => {
     await delay(1000);
     const templates = getLocalStorage<Template[]>(
       LOCAL_STORAGE_KEY_TEMPLATE,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -761,26 +761,39 @@ export const handlers = [
     }
   ),
 
-  http.get(`${DOMAIN}/template/import`, async ({ request }) => {
+  http.get(`${DOMAIN}/template/is_exists`, async ({ request }) => {
     const url = new URL(request.url);
     const category_name = url.searchParams.get("category_name");
     const event_name = url.searchParams.get("event_name");
     await delay(1000);
-    console.log(category_name, event_name);
+
     const templates = getLocalStorage<Template[]>(
       LOCAL_STORAGE_KEY_TEMPLATE,
       []
     );
+    const schedules = getLocalStorage<Schedule[]>(
+      LOCAL_STORAGE_KEY_SCHEDULES,
+      []
+    );
+
     const template = templates.find(
       (t) => t.category_name === category_name && t.template_name === event_name
     );
-    console.log(template);
     if (!template) return HttpResponse.json(null, { status: 400 });
+
+    const schedule = schedules.find(
+      (s) =>
+        s.event_name === template.template_name &&
+        s.category === template.category_name
+    );
 
     return HttpResponse.json(
       {
-        ...template,
-        template_id: template.id,
+        template_data: {
+          ...template,
+          template_id: template.id,
+        },
+        schedule_data: schedule,
       },
       { status: 200 }
     );

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -828,19 +828,40 @@ export const handlers = [
     );
   }),
 
-  http.delete<object, { template_id: string }>(
+  http.delete<object, { template_ids: number[] }>(
     `${DOMAIN}/asset/template/delete`,
     async ({ request }) => {
-      await delay(10000);
-      const { template_id } = await request.json();
+      const { template_ids } = await request.json();
       const templates = getLocalStorage<Template[]>(
         LOCAL_STORAGE_KEY_TEMPLATE,
         []
       );
+      const schedules = getLocalStorage<Schedule[]>(
+        LOCAL_STORAGE_KEY_SCHEDULES,
+        []
+      );
+
+      const deleteTemplates = templates.filter((t) =>
+        template_ids.includes(t.id)
+      );
+      console.log(templates.filter((t) => !template_ids.includes(t.id)));
       setLocalStorage(
         LOCAL_STORAGE_KEY_TEMPLATE,
-        templates.filter((t) => t.id !== Number(template_id))
+        templates.filter((t) => !template_ids.includes(t.id))
       );
+      setLocalStorage(
+        LOCAL_STORAGE_KEY_SCHEDULES,
+        schedules.filter(
+          (s) =>
+            !deleteTemplates.find(
+              (t) =>
+                t.category_name === s.category &&
+                t.template_name === s.event_name
+            )
+        )
+      );
+
+      await delay(10000);
       return HttpResponse.json({ status: 200 });
     }
   ),

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -906,7 +906,8 @@ export const handlers = [
   http.post<object, ModifyTemplateRequest>(
     `${DOMAIN}/asset/template/modify`,
     async ({ request }) => {
-      const { template_id, event_name, category_name } = await request.json();
+      const { template_id, template_name, category_name } =
+        await request.json();
       const templates = getLocalStorage<Template[]>(
         LOCAL_STORAGE_KEY_TEMPLATE,
         []
@@ -923,7 +924,7 @@ export const handlers = [
         schedules.map((s) =>
           s.event_name === template?.template_name &&
           s.category === template.category_name
-            ? { ...s, event_name, category: category_name }
+            ? { ...s, event_name: template_name, category: category_name }
             : s
         )
       );
@@ -931,7 +932,7 @@ export const handlers = [
         LOCAL_STORAGE_KEY_TEMPLATE,
         templates.map((t) =>
           t.id === Number(template_id)
-            ? { ...t, category_name, template_name: event_name }
+            ? { ...t, category_name, template_name }
             : t
         )
       );

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -786,7 +786,7 @@ export const handlers = [
     );
   }),
 
-  http.post(`${DOMAIN}/template/details`, async () => {
+  http.get(`${DOMAIN}/template/details`, async () => {
     await delay(1000);
     const templates = getLocalStorage<Template[]>(
       LOCAL_STORAGE_KEY_TEMPLATE,

--- a/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
+++ b/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
@@ -40,7 +40,7 @@ function ModifyTemplate({ closeDrawer, template }: ModifyTemplateProps) {
     if (answer) {
       await modifyTemplate({
         user_id: template.user_id,
-        event_name: eventName,
+        template_name: eventName,
         category_name: categoryName,
         template_id: template.id.toString(),
       });

--- a/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
+++ b/src/pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/ModifyTemplate.tsx
@@ -1,7 +1,7 @@
 import TopNavigationBar from "@components/layouts/common/TopNavigationBar";
-import { Button, Drawer } from "@mui/material";
+import { Button, Drawer, Stack, Typography } from "@mui/material";
 import { ModifyContainer } from "@pages/AssetManagement/pages/RegularAsset/pages/RegularAssetDetail/components/RegularScheduleList/ModifButton.styles.ts";
-import React, { ChangeEvent, useState } from "react";
+import React, { ChangeEvent, useEffect, useState } from "react";
 import { ModifyRegularAssetsProps } from "@pages/AssetManagement/pages/RegularAsset/pages/ModifyRegularAssets/ModifyRegularAssets.tsx";
 import FormContainer from "@pages/AssetManagement/pages/RegularAsset/pages/ModifyTemplate/components/FormContainer/FormContainer.tsx";
 import { useModifyTemplate } from "@app/tanstack-query/templates/useModifyTemplate.ts";

--- a/src/pages/AssetManagement/pages/RegularAsset/pages/RegularAssetDetail/components/RegularScheduleList/RegularScheduleList.tsx
+++ b/src/pages/AssetManagement/pages/RegularAsset/pages/RegularAssetDetail/components/RegularScheduleList/RegularScheduleList.tsx
@@ -29,10 +29,11 @@ function RegularScheduleList({
   }
 
   const handleModal = (schedule: Schedule) => {
-    schedule &&
-      openScheduleAssetDrawer(SCHEDULE_REQUEST(schedule), (data) =>
-        handleModifyTemplateSchedule(schedule.schedule_id ?? "", data)
-      );
+    if (!schedule) return;
+
+    openScheduleAssetDrawer(SCHEDULE_REQUEST(schedule), (data) =>
+      handleModifyTemplateSchedule(schedule.schedule_id ?? "", data)
+    );
   };
 
   return (


### PR DESCRIPTION
정기 템플릿 서버 api와의 연동을 테스트했습니다.
테스트 과정에서 api 호출 메서드를 올바르게 변경하고, 쿼리 스트링을 명세서에 맞게 추가하는 작업을 진행했습니다.

추가적인 작업으로 자산관리 페이지에서 일정을 수정할 때 일정의 자산 옵션만 수정할 수 있다는 팝업을 추가했습니다.
또한, 템플릿과 동일한 일정명, 카테고리를 사용하지만 템플릿을 적용하지 않는 일정에 대해 일반 일정으로 추가될 수 있도록 하는 로직을 구현했으며, 템플릿의 수가 특정 수를 넘어갔을 때 나오는 알림을 추가했습니다.

close #308