### PR TITLE
fix: 리포트 및 자산관리 페이지 디자인 오류 해결

### DIFF
--- a/src/components/BarChart/BarChart.styles.ts
+++ b/src/components/BarChart/BarChart.styles.ts
@@ -49,7 +49,8 @@ export const BarLabelBox = styled.div<{
   bottom: 6px;
   padding: 3px 10px;
   border-radius: 8px;
-  font-size: 12px;
+  font-size: 11px;
+  white-space: nowrap;
   font-weight: 600;
   color: ${({ $isSelected }) => ($isSelected ? "#fff" : "#131416")};
   background-color: ${({ $isSelected }) =>
@@ -60,7 +61,7 @@ export const LabelLine = styled.div<{
   $isSelected: boolean;
 }>`
   margin: auto;
-  height: 6px;
+  height: 8px;
   border: 1px dashed
     ${({ $isSelected }) => ($isSelected ? "#131416" : "#A9ACB2")};
 `;

--- a/src/components/BarChart/BarChart.tsx
+++ b/src/components/BarChart/BarChart.tsx
@@ -60,7 +60,7 @@ function BarChart({
                 $width={d}
                 onClick={() => setSelected(values[idx])}
               >
-                {selected === values[idx] && `${d}%`}
+                {selected === values[idx] && d > 10 && `${d}%`}
               </BarComponent>
             )
         )}

--- a/src/hooks/assetManagement/useAsset.ts
+++ b/src/hooks/assetManagement/useAsset.ts
@@ -13,9 +13,14 @@ const useAsset = () => {
     navigate(assetManagements[menu].path, { replace: replace });
   };
 
+  const goSpendingGoal = (replace?: boolean) => {
+    setMenu(1, replace);
+  };
+
   return {
     assetMenu,
     setMenu,
+    goSpendingGoal,
   };
 };
 

--- a/src/pages/AssetManagement/pages/AssetBuCategory/AssetByCategory.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/AssetByCategory.tsx
@@ -12,6 +12,8 @@ import { useToast } from "@hooks/toast/useToast.tsx";
 import { IconButton, Typography } from "@mui/material";
 import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
 import Loading from "@components/Loading";
+import useAsset from "@hooks/assetManagement/useAsset.ts";
+import { useDialog } from "@hooks/dialog/useDialog.tsx";
 
 function AssetByCategory() {
   const {
@@ -24,6 +26,8 @@ function AssetByCategory() {
     deleteAssetByCategory,
   } = useAssetByCategory();
   const { openToast, closeToast } = useToast();
+  const { openConfirm } = useDialog();
+  const { goSpendingGoal } = useAsset();
 
   const [control, setControl] = useState("");
 
@@ -59,6 +63,18 @@ function AssetByCategory() {
     }
   };
 
+  const handleSetting = async () => {
+    const result = await openConfirm({
+      title: "알림",
+      content: "지출 목표 설정 페이지로 이동하시겠습니까?",
+      approveText: "네",
+      rejectText: "아니오",
+    });
+    if (result) {
+      goSpendingGoal();
+    }
+  };
+
   return (
     <>
       <SelectMonth
@@ -69,7 +85,7 @@ function AssetByCategory() {
         used={Number(assetsByCategory?.category_total)}
         goal={Number(assetsByCategory?.spend_goal_amount)}
         ratio={parseInt(assetsByCategory?.ratio ?? "0")}
-        handleSetting={() => alert("click")}
+        handleSetting={handleSetting}
       />
       <ThickDivider />
 

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryList.styles.ts
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryList.styles.ts
@@ -6,6 +6,8 @@ export const UnderlinedInput = styled.input<{
 }>`
   border: none;
   outline: none;
+  width: 150px;
+  padding: 0;
   font-size: 16px;
   font-weight: 400;
   text-align: end;
@@ -38,4 +40,8 @@ export const UnderlinedInput = styled.input<{
 export const UnderlinedInputBox = styled.div`
   font-size: 16px;
   font-weight: 400;
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  flex-grow: 1;
 `;

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx
@@ -162,6 +162,7 @@ function CategoryListItem({
             px={4}
             py={2}
             borderBottom="1px solid #F7F7F8"
+            height={55}
           >
             <Typography variant="h4">
               <li>{c.name}</li>

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/CategoryListItem.tsx
@@ -96,7 +96,7 @@ function CategoryListItem({
 
   const handleChangeTotal = (e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.target;
-    const newValue = parseInt(value.replaceAll(",", "")) ?? 0;
+    const newValue = Number(value.replaceAll(",", "")) ?? 0;
     setTotal(newValue);
   };
 

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/components/ListItemHeader/ListItemHeader.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/CategoryList/CategoryListItem/components/ListItemHeader/ListItemHeader.tsx
@@ -41,17 +41,8 @@ function ListItemHeader({
       bgcolor={open ? "#EAE1FD" : "#fff"}
       borderBottom="1px solid #F7F7F8"
     >
-      {/*<Avatar*/}
-      {/*  alt="category icon"*/}
-      {/*  src={CATEGORY_ICONS[category.subCategory[0]]}*/}
-      {/*  sx={{ width: 42, height: 42 }}*/}
-      {/*>*/}
-      {/*  {category.name}*/}
-      {/*</Avatar>*/}
       <CategoryIconSVG id={category.subCategory[0]} size={42} />
-      <Typography variant="h4" sx={{ flexGrow: 1 }}>
-        {category.name}
-      </Typography>
+      <Typography variant="h4">{category.name}</Typography>
       {modifyTotal ? (
         <UnderlinedInputBox>
           <UnderlinedInput
@@ -65,7 +56,11 @@ function ListItemHeader({
           <span>원</span>
         </UnderlinedInputBox>
       ) : (
-        <Typography variant="h5" onClick={handleClickTotal}>
+        <Typography
+          variant="h5"
+          onClick={handleClickTotal}
+          sx={{ flexGrow: 1, textAlign: "end" }}
+        >
           {total.toLocaleString()}원
         </Typography>
       )}

--- a/src/pages/AssetManagement/pages/AssetBuCategory/components/SummaryCard/SummaryCard.tsx
+++ b/src/pages/AssetManagement/pages/AssetBuCategory/components/SummaryCard/SummaryCard.tsx
@@ -31,7 +31,7 @@ function SummaryCard({ ratio, used, goal, handleSetting }: SummaryCardProps) {
             onClick={handleSetting}
             sx={{ flexGrow: 1, display: "flex", alignItems: "center" }}
           >
-            <IconSVG id={"setting-secondary"} size={24} />
+            <IconSVG id={"setting-secondary"} size={20} />
           </Box>
           <Typography fontWeight={500}>{goal.toLocaleString()}원</Typography>
         </Stack>

--- a/src/pages/reports/Report/Report.tsx
+++ b/src/pages/reports/Report/Report.tsx
@@ -93,7 +93,7 @@ function Report() {
           titleIcon={
             <img src={money_icon} alt="info" width="28px" height="28px" />
           }
-          amount={Math.abs(report.available_amount)}
+          amount={Number(report.available_amount)}
           navigateIcon={<img src={info_icon} alt="info" />}
           handleClick={handleClickAccountInfo}
         />

--- a/src/pages/reports/Report/Report.tsx
+++ b/src/pages/reports/Report/Report.tsx
@@ -21,9 +21,9 @@ import BubbleChart from "@pages/reports/Report/components/BubbleChart";
 import PredictReport from "@pages/reports/Report/components/PredictReport";
 import { useEffect, useState } from "react";
 import GoalSettingModal from "@pages/reports/Report/components/modals/GoalSettingModal";
-import { useNavigate } from "react-router-dom";
 import Loading from "@components/Loading";
 import { useOnBoarding } from "@hooks/onboarding/useOnBoarding.tsx";
+import useAsset from "@hooks/assetManagement/useAsset.ts";
 
 function Report() {
   const { year, month, report, reportList, isPending, isError, pickMonth } =
@@ -31,8 +31,8 @@ function Report() {
   useHeader(true, HEADER_MODE.analysis);
   const { openModal, closeModal } = useModal();
   const [selected, setSelected] = useState("used");
-  const navigate = useNavigate();
   const { reportTutorial, openReportTutorial } = useOnBoarding();
+  const { goSpendingGoal } = useAsset();
 
   useEffect(() => {
     if (!reportTutorial) {
@@ -54,7 +54,7 @@ function Report() {
           closeModal={closeModal}
           navigateTo={() => {
             closeModal();
-            navigate(PATH.spendingGoal);
+            goSpendingGoal(false);
           }}
         />
       ),

--- a/src/pages/reports/Report/components/PredictReport/PredictReport.tsx
+++ b/src/pages/reports/Report/components/PredictReport/PredictReport.tsx
@@ -46,7 +46,7 @@ function PredictReport({
 
       <DoughnutChart
         labels={LABELS}
-        datas={datas}
+        datas={datas.map((data) => (data < 0 ? 0 : data))}
         bgColors={colors}
         selected={selected}
         setSelected={setSelected}
@@ -60,7 +60,7 @@ function PredictReport({
             type={type}
             amount={datas[idx]}
             selected={selected === type.type}
-            over={useable === 0}
+            over={useable <= 0}
             setSelected={setSelected}
           />
         ))}


### PR DESCRIPTION
리포트 페이지
- 소비 예측 리포트 음수인 데이터가 양수처럼 그래프 영역을 차지하는 문제를 해결했습니다.
- 사용 가능 금액 절댓값이 아닌 정수로 넘겨 음수 값도 표현할 수 있도록 수정했습니다.
- 지출 목표 페이지로 이동하는 로직을 수정했습니다.

자산관리 페이지
- BarChart의 BarLabel이 중첩되는 문제를 해결하기 위해 font-size를 조정했습니다.
- BarChart의 퍼센트 표시가 잘리는 문제를 해결하기 위해 표시되는 기준을 11%로 지정해줬습니다.
- 카테고리 지출 목표 금액 설정 시 빈 값을 입력할 경우 오류가 나는 문제를 해결했습니다.
- 카테고리 지출 목표 금액 설정 input에 의해 디자인이 깨지는 문제를 해결하기 위해 input의 너비를 고정했습니다.

close #314