### PR TITLE
refactor: change schedule api request data

### DIFF
--- a/src/app/tanstack-query/assetManagement/savingGoal/useGoals.ts
+++ b/src/app/tanstack-query/assetManagement/savingGoal/useGoals.ts
@@ -15,6 +15,7 @@ const fetchGoal = async (user_id: string) => {
       Authorization: "Bearer " + token,
     },
   }).then<SavingGoal>(async (res) => {
+    console.log(`${DOMAIN}/asset/target-amount?userId=${user_id}`);
     return res.json();
   });
 };

--- a/src/app/tanstack-query/assetManagement/spedingGoal/useSetSpendingGoal.ts
+++ b/src/app/tanstack-query/assetManagement/spedingGoal/useSetSpendingGoal.ts
@@ -7,6 +7,7 @@ import { setSpendingGoal } from "@app/types/asset.ts";
 
 const fetchSetSpendingGoal = async (query: setSpendingGoal) => {
   const token = getSessionStorage(SESSION_STORAGE_KEY_TOKEN, "");
+  console.log(DOMAIN);
 
   return fetch(`${DOMAIN}/asset/spend-goal/set`, {
     method: "POST",

--- a/src/hooks/schedule/useSchedule.ts
+++ b/src/hooks/schedule/useSchedule.ts
@@ -7,7 +7,6 @@ import {
 } from "@redux/slices/scheduleSlice.tsx";
 import { RequestSchedule } from "@app/types/schedule.ts";
 import { useAppDispatch } from "@redux/hooks.ts";
-import { v4 as uuidv4 } from "uuid";
 import { useCreateSchedule } from "@app/tanstack-query/schedules/useCreateSchedule.ts";
 import { useUser } from "@app/tanstack-query/useUser.ts";
 import { INIT_SCHEDULE } from "@constants/schedule.ts";
@@ -39,14 +38,12 @@ const useSchedule = () => {
       return alert("로그인이 필요합니다.");
     }
 
-    const scheduleWithUuid = {
+    const newSchedule = {
       ...schedule,
-      schedule_id: uuidv4(),
       user_id: user.user_id,
     };
-    console.log(scheduleWithUuid);
 
-    createSchedule(scheduleWithUuid);
+    createSchedule(newSchedule);
     resetSchedule();
   };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,16 @@ export default defineConfig({
       "/local": {
         target: "http://localhost:8080",
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/local/, ""),
+        rewrite: (path) => {
+          console.log(path.replace(/\/local&/, ""));
+          return path.replace(/^\/local/, "");
+        },
+      },
+      "/management": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+        rewrite: (path) =>
+          path.replace(/^\/management/, "").replace(/^\/local/, ""),
       },
     },
   },


### PR DESCRIPTION
일정 추가 api의 request data에서 schedule_id를 제거했습니다.

자산관리 페이지에서 api path에 management가 추가되는 문제가 있어 vite.config.ts 파일에서 proxy 설정으로 개선했습니다.

close #undefined