### PR TITLE
fix: schedule list page path error

### DIFF
--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -5,7 +5,7 @@ export const PATH = {
   signUp: "/sign-up",
 
   home: "/home",
-  scheduleList: "schedule-list",
+  scheduleList: "/schedule-list",
   myPage: "/myPage",
   notification: "/notification",
   searchSchedule: "/search=schedule",


### PR DESCRIPTION
스케쥴 페이지 경로 에러를 해결했습니다.

상대경로로 지정되어 있던 것을 절대 경로로 수정했습니다.

close #undefined