### PR TITLE
fix: component design

### DIFF
--- a/src/app/redux/slices/assetSlice.tsx
+++ b/src/app/redux/slices/assetSlice.tsx
@@ -1,13 +1,16 @@
 /* eslint-disable no-param-reassign */
 import { createSlice } from "@reduxjs/toolkit";
 import { RootState } from "../store";
+import moment from "moment";
 
 interface InitialState {
   assetMenu: number;
+  reportDate: string;
 }
 
 const initialState: InitialState = {
   assetMenu: 0,
+  reportDate: moment().format("YYYY-MM-DD"),
 };
 
 export const assetSlice = createSlice({
@@ -17,10 +20,14 @@ export const assetSlice = createSlice({
     setAssetMenu: (state, action) => {
       state.assetMenu = action.payload;
     },
+    setReportDate: (state, action) => {
+      state.reportDate = action.payload;
+    },
   },
 });
-export const { setAssetMenu } = assetSlice.actions;
+export const { setAssetMenu, setReportDate } = assetSlice.actions;
 
 export const selectAssetMenu = (state: RootState) => state.asset.assetMenu;
+export const selectReportDate = (state: RootState) => state.asset.reportDate;
 
 export default assetSlice.reducer;

--- a/src/app/tanstack-query/useAuth.ts
+++ b/src/app/tanstack-query/useAuth.ts
@@ -39,8 +39,7 @@ export const useAuth = () => {
         .get("Authorization")
         ?.split("Bearer ")[1];
 
-      console.log(accessToken);
-      if (user !== "") {
+      if (data.ok && user) {
         const useUser: User = {
           name: user.name,
           user_id: variable.user_id?.toString() ?? "",
@@ -51,14 +50,18 @@ export const useAuth = () => {
         setCookie(COOKIE_KEY_ACCESS_TOKEN, accessToken);
         navigate(PATH.home);
       } else {
-        alert("로그인에 실패했습니다.");
+        openToast({
+          hideDuration: 4000,
+          color: "error.light",
+          toastText: "이메일 또는 비밀번호가 다릅니다.",
+        });
       }
     },
     onError: () => {
       openToast({
         hideDuration: 4000,
         color: "error.light",
-        toastText: "이메일 또는 비밀번호가 다릅니다.",
+        toastText: "로그인에 실패했습니다.",
       });
     },
   });

--- a/src/app/tanstack-query/useAuth.ts
+++ b/src/app/tanstack-query/useAuth.ts
@@ -75,6 +75,7 @@ export const useAuth = () => {
     queryClient.setQueryData([QUERY_KEY_USER], null);
     sessionStorage.clear();
     deleteCookie([COOKIE_KEY_REFRESH_TOKEN, COOKIE_KEY_ACCESS_TOKEN]);
+    navigate(PATH.start, { replace: true });
   };
 
   return { signIn, signOut, isPending };

--- a/src/app/tanstack-query/useUser.ts
+++ b/src/app/tanstack-query/useUser.ts
@@ -7,7 +7,6 @@ import { DOMAIN } from "@api/url.ts";
 
 const fetchUser = async () => {
   const token = getCookie(COOKIE_KEY_ACCESS_TOKEN);
-  console.log(token?.split(".").length);
 
   return fetch(`${DOMAIN}/api/user/info`, {
     method: "POST",

--- a/src/components/layouts/containerLayout/HomeLayout.tsx
+++ b/src/components/layouts/containerLayout/HomeLayout.tsx
@@ -7,12 +7,10 @@ import OverlayProvider from "@hooks/use-overlay/OverlayProvider.tsx";
 import { useUser } from "@app/tanstack-query/useUser.ts";
 import { useEffect } from "react";
 import { getCookie } from "@utils/storage.ts";
-import {
-  COOKIE_KEY_ACCESS_TOKEN,
-  COOKIE_KEY_REFRESH_TOKEN,
-} from "@api/keys.ts";
+import { COOKIE_KEY_ACCESS_TOKEN } from "@api/keys.ts";
 import { QUERY_KEY_USER } from "@constants/queryKeys.ts";
 import { useQueryClient } from "@tanstack/react-query";
+import { useAuth } from "@app/tanstack-query/useAuth.ts";
 
 export default function HomeLayout() {
   const navigate = useNavigate();
@@ -21,11 +19,12 @@ export default function HomeLayout() {
   const bottomBarOpen = useAppSelector(selectBottomBarOpen);
 
   const { data: user } = useUser();
+  const { signOut } = useAuth();
   const accessToken = getCookie(COOKIE_KEY_ACCESS_TOKEN);
 
   useEffect(() => {
     if (!accessToken) {
-      return navigate("/");
+      return signOut();
     }
   }, [accessToken]);
 

--- a/src/hooks/report/useCategoryReport.ts
+++ b/src/hooks/report/useCategoryReport.ts
@@ -4,6 +4,7 @@ import { useUser } from "@app/tanstack-query/useUser.ts";
 import moment from "moment";
 import { useCategoryDetail } from "@app/tanstack-query/reports/useCategoryDetail.ts";
 import { useParams } from "react-router-dom";
+import { useSetSpendingGoal } from "@app/tanstack-query/assetManagement/spedingGoal/useSetSpendingGoal.ts";
 
 const useCategoryReport = () => {
   const [yearMonth, setYearMonth] = useState(moment().format("YYYY-MM"));
@@ -19,6 +20,7 @@ const useCategoryReport = () => {
     date: `${yearMonth}-${moment().format("DD")}`,
     category: params.category?.replace("-", "/") ?? "",
   });
+  const { setSpendingGoal } = useSetSpendingGoal();
   const { openMonthPicker } = useDatePicker();
 
   const addMonth = () => {
@@ -36,6 +38,17 @@ const useCategoryReport = () => {
     setYearMonth(newMonth.format("YYYY-MM"));
   };
 
+  const handleSetSpendingGoal = (goal: string) => {
+    setSpendingGoal({
+      start_date: yearMonth,
+      end_date: yearMonth,
+      regular: "OFF" as const,
+      is_batch: false,
+      user_id: user?.user_id ?? "",
+      spend_goal_amount: goal,
+    });
+  };
+
   return {
     yearMonth,
     year,
@@ -46,6 +59,7 @@ const useCategoryReport = () => {
     addMonth,
     subtractMonth,
     pickMonth,
+    handleSetSpendingGoal,
   };
 };
 

--- a/src/hooks/report/useCategoryReport.ts
+++ b/src/hooks/report/useCategoryReport.ts
@@ -1,14 +1,8 @@
-import { useState } from "react";
-import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
 import { useUser } from "@app/tanstack-query/useUser.ts";
-import moment from "moment";
 import { useCategoryDetail } from "@app/tanstack-query/reports/useCategoryDetail.ts";
 import { useParams } from "react-router-dom";
-import { useSetSpendingGoal } from "@app/tanstack-query/assetManagement/spedingGoal/useSetSpendingGoal.ts";
 
-const useCategoryReport = () => {
-  const [yearMonth, setYearMonth] = useState(moment().format("YYYY-MM"));
-  const [year, month] = yearMonth.split("-").map((s) => Number(s));
+const useCategoryReport = (initialDate: string) => {
   const { data: user } = useUser();
   const params = useParams();
   const {
@@ -17,49 +11,14 @@ const useCategoryReport = () => {
     isError,
   } = useCategoryDetail({
     user_id: user?.user_id ?? "",
-    date: `${yearMonth}-${moment().format("DD")}`,
+    date: initialDate,
     category: params.category?.replace("-", "/") ?? "",
   });
-  const { setSpendingGoal } = useSetSpendingGoal();
-  const { openMonthPicker } = useDatePicker();
-
-  const addMonth = () => {
-    const date = moment(yearMonth, "YYYY-MM");
-    setYearMonth(date.add(1, "month").format("YYYY-MM"));
-  };
-
-  const subtractMonth = () => {
-    const date = moment(yearMonth, "YYYY-MM");
-    setYearMonth(date.subtract(1, "month").format("YYYY-MM"));
-  };
-
-  const pickMonth = async () => {
-    const newMonth = await openMonthPicker(yearMonth);
-    setYearMonth(newMonth.format("YYYY-MM"));
-  };
-
-  const handleSetSpendingGoal = (goal: string) => {
-    setSpendingGoal({
-      start_date: yearMonth,
-      end_date: yearMonth,
-      regular: "OFF" as const,
-      is_batch: false,
-      user_id: user?.user_id ?? "",
-      spend_goal_amount: goal,
-    });
-  };
 
   return {
-    yearMonth,
-    year,
-    month,
     report,
     isPending,
     isError,
-    addMonth,
-    subtractMonth,
-    pickMonth,
-    handleSetSpendingGoal,
   };
 };
 

--- a/src/hooks/report/useMonth.ts
+++ b/src/hooks/report/useMonth.ts
@@ -1,0 +1,45 @@
+import { useAppDispatch, useAppSelector } from "@redux/hooks.ts";
+import { selectReportDate, setReportDate } from "@redux/slices/assetSlice.tsx";
+import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
+import moment from "moment";
+
+const useMonth = () => {
+  const dispatch = useAppDispatch();
+  const reportDate = useAppSelector(selectReportDate);
+
+  const { openMonthPicker } = useDatePicker();
+
+  const yearMonth = moment(reportDate).format("YYYY-MM");
+  const [year, month] = yearMonth.split("-").map((s) => Number(s));
+
+  const addMonth = () => {
+    dispatch(
+      setReportDate(moment(reportDate).add(1, "month").format("YYYY-MM-DD"))
+    );
+  };
+
+  const subtractMonth = () => {
+    dispatch(
+      setReportDate(
+        moment(reportDate).subtract(1, "month").format("YYYY-MM-DD")
+      )
+    );
+  };
+
+  const pickMonth = async () => {
+    const newMonth = await openMonthPicker(yearMonth);
+    dispatch(setReportDate(newMonth.format("YYYY-MM-DD")));
+  };
+
+  return {
+    date: reportDate,
+    yearMonth,
+    year,
+    month,
+    addMonth,
+    subtractMonth,
+    pickMonth,
+  };
+};
+
+export default useMonth;

--- a/src/hooks/report/useReport.ts
+++ b/src/hooks/report/useReport.ts
@@ -1,24 +1,18 @@
-import { useState } from "react";
-import { useDatePicker } from "@hooks/date-picker/hooks/useDatePicker.tsx";
 import { useUser } from "@app/tanstack-query/useUser.ts";
 import { useReports } from "@app/tanstack-query/reports/useReports.ts";
-import moment from "moment";
-import { useSetGoal } from "@app/tanstack-query/reports/useSetGoal.ts";
 
-const useReport = () => {
-  const [yearMonth, setYearMonth] = useState(moment().format("YYYY-MM"));
-  const [year, month] = yearMonth.split("-").map((s) => Number(s));
+const useReport = (initialDate: string) => {
   const { data: user } = useUser();
+
   const {
     data: report,
     isPending,
     isError,
   } = useReports({
     user_id: user?.user_id ?? "",
-    date: `${yearMonth}-${moment().format("DD")}`,
+    date: initialDate,
   });
-  const { openMonthPicker } = useDatePicker();
-  const { setGoal } = useSetGoal();
+
   const reportList =
     report?.category_consume_list === "?" ? [] : report?.category_consume_list;
 
@@ -26,45 +20,12 @@ const useReport = () => {
     ...(reportList?.map((l) => parseFloat(l.rate)) ?? [])
   );
 
-  const addMonth = () => {
-    const date = moment(yearMonth, "YYYY-MM");
-    setYearMonth(date.add(1, "month").format("YYYY-MM"));
-  };
-
-  const subtractMonth = () => {
-    const date = moment(yearMonth, "YYYY-MM");
-    setYearMonth(date.subtract(1, "month").format("YYYY-MM"));
-  };
-
-  const pickMonth = async () => {
-    const newMonth = await openMonthPicker(yearMonth);
-    setYearMonth(newMonth.format("YYYY-MM"));
-  };
-
-  const setExpenditureGoal = (amount: number) => {
-    if (user) {
-      setGoal({
-        user_id: user.user_id,
-        date: yearMonth,
-        expenditure_amount: amount.toString(),
-      });
-    }
-  };
-
   return {
-    yearMonth,
-    year,
-    month,
     report,
     isPending,
     isError,
-    openMonthPicker,
     reportList,
     maxPercent,
-    addMonth,
-    subtractMonth,
-    pickMonth,
-    setExpenditureGoal,
   };
 };
 

--- a/src/hooks/schedule/useSchedule.ts
+++ b/src/hooks/schedule/useSchedule.ts
@@ -13,8 +13,6 @@ import { INIT_SCHEDULE } from "@constants/schedule.ts";
 import { useModifySchedule } from "@app/tanstack-query/schedules/useModifySchedule.ts";
 import { useDeleteSchedule } from "@app/tanstack-query/schedules/useDeleteSchedule.ts";
 import { useMonthSchedules } from "@app/tanstack-query/home/useMonthSchedules.ts";
-import { getCookie } from "@utils/storage.ts";
-import { COOKIE_KEY_REFRESH_TOKEN } from "@api/keys.ts";
 
 const useSchedule = () => {
   const dispatch = useAppDispatch();

--- a/src/pages/AssetManagement/AssetManagement.tsx
+++ b/src/pages/AssetManagement/AssetManagement.tsx
@@ -15,7 +15,7 @@ import ThickDivider from "@components/common/ThickDivider.tsx";
 
 function AssetManagement() {
   const dispatch = useAppDispatch();
-  const { schedules } = useSchedule();
+  const { schedules, data } = useSchedule();
   const { data: user } = useUser();
 
   const today = moment();
@@ -59,6 +59,7 @@ function AssetManagement() {
               )
           ).length ?? 0
         }
+        available={parseInt(data?.available ?? "")}
       />
     </Stack>
   );

--- a/src/pages/AssetManagement/components/ScheduleStatusCard/ScheduleStatusCard.tsx
+++ b/src/pages/AssetManagement/components/ScheduleStatusCard/ScheduleStatusCard.tsx
@@ -1,15 +1,16 @@
 import { Box, Stack } from "@mui/material";
-import RoundedBorderBox from "../../../../components/common/RoundedBorderBox.tsx";
 import StatusCard from "@pages/AssetManagement/components/ScheduleStatusCard/components/StatusCard/StatusCard.tsx";
 
 interface ScheduleStatusCardProps {
   month: string;
   numberOfSchedule: number;
+  available: number;
 }
 
 function ScheduleStatusCard({
   month,
   numberOfSchedule,
+  available,
 }: ScheduleStatusCardProps) {
   return (
     <Stack px={2.5} spacing="21px">
@@ -20,7 +21,10 @@ function ScheduleStatusCard({
           content={`${numberOfSchedule}개`}
         />
 
-        <StatusCard title="추천 소비 금액" content="xxxxx원" />
+        <StatusCard
+          title="사용 가능 금액"
+          content={`${available.toLocaleString()}원`}
+        />
       </Stack>
     </Stack>
   );

--- a/src/pages/MyPage/MyPage.tsx
+++ b/src/pages/MyPage/MyPage.tsx
@@ -1,6 +1,4 @@
 import { Box, Button, Stack, Typography } from "@mui/material";
-import { useNavigate } from "react-router-dom";
-import { PATH } from "@constants/path.ts";
 import GuestMode from "./GuestMode.tsx";
 import ScheduleFilterData from "./ScheduleFilterData.tsx";
 import { useAppSelector } from "@redux/hooks.ts";
@@ -14,7 +12,6 @@ import { getCookie } from "@utils/storage.ts";
 import { COOKIE_KEY_REFRESH_TOKEN } from "@api/keys.ts";
 
 function MyPage() {
-  const navigate = useNavigate();
   const guestMode = useAppSelector(selectGuestMode);
   const refreshToken = getCookie(COOKIE_KEY_REFRESH_TOKEN);
   const { signOut } = useAuth();
@@ -26,7 +23,6 @@ function MyPage() {
       )
     ) {
       signOut();
-      navigate(PATH.start, { replace: true });
     }
   };
 

--- a/src/pages/reports/Report/Report.stories.tsx
+++ b/src/pages/reports/Report/Report.stories.tsx
@@ -17,6 +17,7 @@ import moment from "moment";
 import PredictReport from "@pages/reports/Report/components/PredictReport";
 import FixedTransaction from "@pages/reports/Report/components/FixedTransaction";
 import MonthlyReport from "@pages/reports/Report/components/MonthlyReport";
+import { PATH } from "@constants/path.ts";
 
 const meta = {
   title: "reports/Report",
@@ -139,7 +140,8 @@ export const PageExample = () => {
           content={
             <ReportLayout
               title="월간 소비 리포트"
-              navigateTo="/somewhere"
+              handleClick={() => alert("click")}
+              actionContent="자세히 보기"
               content={<BubbleChart bubbles={generateRandomBubbles2(list)} />}
             />
           }
@@ -149,6 +151,8 @@ export const PageExample = () => {
             <Stack spacing={5}>
               <ReportLayout
                 title="소비 예측 리포트"
+                handleClick={() => alert("click")}
+                actionContent="지출 목표 설정하기"
                 content={
                   <PredictReport
                     selected={selected}

--- a/src/pages/reports/Report/Report.tsx
+++ b/src/pages/reports/Report/Report.tsx
@@ -25,6 +25,7 @@ import Loading from "@components/Loading";
 import { useOnBoarding } from "@hooks/onboarding/useOnBoarding.tsx";
 import useAsset from "@hooks/assetManagement/useAsset.ts";
 import useMonth from "@hooks/report/useMonth.ts";
+import { useNavigate } from "react-router-dom";
 
 function Report() {
   const { date, year, month, pickMonth } = useMonth();
@@ -34,6 +35,7 @@ function Report() {
   const [selected, setSelected] = useState("used");
   const { reportTutorial, openReportTutorial } = useOnBoarding();
   const { goSpendingGoal } = useAsset();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!reportTutorial) {
@@ -103,7 +105,8 @@ function Report() {
         content={
           <ReportLayout
             title="월간 소비 리포트"
-            navigateTo={PATH.reportMonthDetail}
+            handleClick={() => navigate(PATH.reportMonthDetail)}
+            actionContent="자세히 보기"
             content={
               <BubbleChart bubbles={generateRandomBubbles2(reportList)} />
             }
@@ -115,6 +118,12 @@ function Report() {
           <Stack spacing={5}>
             <ReportLayout
               title="소비 예측 리포트"
+              actionContent={
+                Number(report.expenditure_data.spend_amount)
+                  ? undefined
+                  : "지출 목표 설정하기"
+              }
+              handleClick={handleClickAccountSetting}
               content={
                 <PredictReport
                   selected={selected}

--- a/src/pages/reports/Report/Report.tsx
+++ b/src/pages/reports/Report/Report.tsx
@@ -24,10 +24,11 @@ import GoalSettingModal from "@pages/reports/Report/components/modals/GoalSettin
 import Loading from "@components/Loading";
 import { useOnBoarding } from "@hooks/onboarding/useOnBoarding.tsx";
 import useAsset from "@hooks/assetManagement/useAsset.ts";
+import useMonth from "@hooks/report/useMonth.ts";
 
 function Report() {
-  const { year, month, report, reportList, isPending, isError, pickMonth } =
-    useReport();
+  const { date, year, month, pickMonth } = useMonth();
+  const { report, reportList, isPending, isError } = useReport(date);
   useHeader(true, HEADER_MODE.analysis);
   const { openModal, closeModal } = useModal();
   const [selected, setSelected] = useState("used");

--- a/src/pages/reports/Report/ReportTutorial.tsx
+++ b/src/pages/reports/Report/ReportTutorial.tsx
@@ -252,7 +252,7 @@ function ReportTutorial({ closeTutorial }: { closeTutorial: () => void }) {
           content={
             <ReportLayout
               title="월간 소비 리포트"
-              navigateTo={PATH.reportMonthDetail}
+              actionContent="자세히 보기"
               content={<TutorialBubbleChart />}
             />
           }

--- a/src/pages/reports/Report/components/layout/ReportLayout/ReportLayout.stories.tsx
+++ b/src/pages/reports/Report/components/layout/ReportLayout/ReportLayout.stories.tsx
@@ -7,13 +7,19 @@ const meta = {
   tags: ["autodocs"],
   args: {
     title: "리포트 이름",
-    navigateTo: "/report/2021-05",
+    actionContent: "서브 액션 컨텐트",
+    handleClick: () => alert("click"),
     content: "리포트 콘텐츠 컴포넌트가 올 자리",
   },
   argTypes: {
-    navigateTo: {
-      description:
-        "더보기 버튼을 눌렀을 때 이동할 경로를 지정합니다. 텍스트가 없으면 뜨지 않습니다.",
+    title: {
+      description: "리포트 카드의 제목입니다.",
+    },
+    actionContent: {
+      description: "리포트 카드에 사용할 서브 액션 텍스트를 나타냅니다.",
+    },
+    handleClick: {
+      description: "서브 동작의 액션 핸들러입니다.",
     },
     content: {
       description:

--- a/src/pages/reports/Report/components/layout/ReportLayout/ReportLayout.tsx
+++ b/src/pages/reports/Report/components/layout/ReportLayout/ReportLayout.tsx
@@ -1,32 +1,37 @@
 import { ReactNode } from "react";
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import { useNavigate } from "react-router-dom";
 
 export interface ReportLayoutProps {
   title: string;
-  navigateTo?: `/${string}`;
+  actionContent?: string;
+  handleClick?: () => void;
   content?: ReactNode;
 }
 
-function ReportLayout({ navigateTo, title, content }: ReportLayoutProps) {
-  const navigate = useNavigate();
+function ReportLayout({
+  actionContent,
+  handleClick,
+  title,
+  content,
+}: ReportLayoutProps) {
   return (
     <Stack spacing={1}>
       <Stack direction="row" alignItems="center" justifyContent="space-between">
         <Typography fontSize="20px" fontWeight={700}>
           {title}
         </Typography>
-        {navigateTo && (
+        {actionContent && (
           <Stack
             direction="row"
             alignItems="center"
             spacing={0.5}
             py={2}
             sx={{ fontSize: "14px", fontWeight: 500, color: "primary.main" }}
-            onClick={() => navigate(navigateTo)}
+            onClick={handleClick}
           >
-            <Box>자세히 보기</Box>
+            <Box>{actionContent}</Box>
             <ArrowForwardIosIcon
               fontSize="inherit"
               sx={{ color: "secondary.dark" }}

--- a/src/pages/reports/ReportCategoryDetails/ReportCategoryDetails.tsx
+++ b/src/pages/reports/ReportCategoryDetails/ReportCategoryDetails.tsx
@@ -4,12 +4,14 @@ import useCategoryReport from "@hooks/report/useCategoryReport.ts";
 import useBottomBar from "@hooks/useBottomBar.ts";
 import ReportCategoryBody from "@pages/reports/ReportCategoryDetails/components/ReportCategoryBody";
 import useAsset from "@hooks/assetManagement/useAsset.ts";
+import useMonth from "@hooks/report/useMonth.ts";
 
 function ReportCategoryDetails() {
   useHeader(false);
   useBottomBar(false);
-  const { report, isPending, year, month, addMonth, subtractMonth, pickMonth } =
-    useCategoryReport();
+
+  const { date, year, month, pickMonth, subtractMonth, addMonth } = useMonth();
+  const { report, isPending } = useCategoryReport(date);
   const { setMenu } = useAsset();
 
   const handleClickSetSpendGoal = () => {

--- a/src/pages/reports/ReportCategoryDetails/ReportCategoryDetails.tsx
+++ b/src/pages/reports/ReportCategoryDetails/ReportCategoryDetails.tsx
@@ -1,30 +1,19 @@
 import useHeader from "@hooks/useHeader.ts";
 import ScheduleListPageHeader from "components/ScheduleList/ScheduleListPageHeader";
 import useCategoryReport from "@hooks/report/useCategoryReport.ts";
-import { useScheduleDrawer } from "@hooks/useScheduleDrawer.tsx";
-import moment from "moment/moment";
-import { INIT_SCHEDULE } from "@constants/schedule.ts";
 import useBottomBar from "@hooks/useBottomBar.ts";
 import ReportCategoryBody from "@pages/reports/ReportCategoryDetails/components/ReportCategoryBody";
+import useAsset from "@hooks/assetManagement/useAsset.ts";
 
 function ReportCategoryDetails() {
   useHeader(false);
   useBottomBar(false);
-  const {
-    report,
-    isPending,
-    year,
-    month,
-    yearMonth,
-    addMonth,
-    subtractMonth,
-    pickMonth,
-  } = useCategoryReport();
-  const { openScheduleDrawer } = useScheduleDrawer();
+  const { report, isPending, year, month, addMonth, subtractMonth, pickMonth } =
+    useCategoryReport();
+  const { setMenu } = useAsset();
 
-  const handleClickAddSchedule = () => {
-    const date = moment(yearMonth, "YYYY-MM");
-    openScheduleDrawer(INIT_SCHEDULE(date.format("YYYY-MM-DD")));
+  const handleClickSetSpendGoal = () => {
+    setMenu(2, false);
   };
 
   return (
@@ -41,7 +30,7 @@ function ReportCategoryDetails() {
       <ReportCategoryBody
         report={report}
         isPending={isPending}
-        handleClickAddSchedule={handleClickAddSchedule}
+        handleClickAddSchedule={handleClickSetSpendGoal}
       />
     </>
   );

--- a/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
+++ b/src/pages/reports/ReportCategoryDetails/components/ReportCategoryBody/ReportCategoryBody.tsx
@@ -75,7 +75,12 @@ function ReportCategoryBody({
   }
 
   if (scheduleDates.length === 0) {
-    return <ReportEmptyBox handleClickAddSchedule={handleClickAddSchedule} />;
+    return (
+      <ReportEmptyBox
+        handleClickAddSchedule={handleClickAddSchedule}
+        mode="spendGoal"
+      />
+    );
   }
 
   const scrollToToday = () => {

--- a/src/pages/reports/ReportMonthDetails/ReportMonthDetails.tsx
+++ b/src/pages/reports/ReportMonthDetails/ReportMonthDetails.tsx
@@ -10,21 +10,14 @@ import { INIT_SCHEDULE } from "@constants/schedule.ts";
 import moment from "moment";
 import { PATH } from "@constants/path.ts";
 import useBottomBar from "@hooks/useBottomBar.ts";
+import useMonth from "@hooks/report/useMonth.ts";
 
 function ReportMonthDetails() {
   useHeader(false);
   useBottomBar(false);
   const navigate = useNavigate();
-  const {
-    yearMonth,
-    year,
-    month,
-    pickMonth,
-    isPending,
-    report,
-    reportList,
-    maxPercent,
-  } = useReport();
+  const { date, yearMonth, year, month, pickMonth } = useMonth();
+  const { isPending, report, reportList, maxPercent } = useReport(date);
   const { openScheduleDrawer } = useScheduleDrawer();
 
   const handleClickAddSchedule = () => {

--- a/src/pages/reports/ReportMonthDetails/components/ReportEmptyBox/ReportEmptyBox.tsx
+++ b/src/pages/reports/ReportMonthDetails/components/ReportEmptyBox/ReportEmptyBox.tsx
@@ -4,15 +4,22 @@ import { SCHEDULE_DRAWER } from "@constants/schedule.ts";
 
 export interface ReportEmptyBoxProps {
   handleClickAddSchedule: () => void;
+  mode: "schedule" | "spendGoal";
 }
 
-function ReportEmptyBox({ handleClickAddSchedule }: ReportEmptyBoxProps) {
+function ReportEmptyBox({ mode, handleClickAddSchedule }: ReportEmptyBoxProps) {
   return (
     <Stack spacing={2} alignItems="center">
       <img src={warning_icon} alt="warning" />
-      <Typography fontSize="16px">소비 데이터가 없습니다.</Typography>
+      <Typography fontSize="16px">
+        {mode === "schedule"
+          ? "소비 데이터가 없습니다."
+          : "카체고리별 지출 목표가 미설정되었습니다."}
+      </Typography>
       <Button variant="contained" onClick={handleClickAddSchedule}>
-        {SCHEDULE_DRAWER.add_schedule}
+        {mode === "schedule"
+          ? SCHEDULE_DRAWER.add_schedule
+          : "카테고리별 지출 목표 설정하기"}
       </Button>
     </Stack>
   );

--- a/src/pages/reports/ReportMonthDetails/components/ReportEmptyBox/ReportEmpyBox.stories.tsx
+++ b/src/pages/reports/ReportMonthDetails/components/ReportEmptyBox/ReportEmpyBox.stories.tsx
@@ -1,12 +1,15 @@
-import {Meta} from "@storybook/react";
+import { Meta } from "@storybook/react";
 import ReportEmptyBox from "@pages/reports/ReportMonthDetails/components/ReportEmptyBox";
-import {ReportEmptyBoxProps} from "@pages/reports/ReportMonthDetails/components/ReportEmptyBox/ReportEmptyBox.tsx";
+import { ReportEmptyBoxProps } from "@pages/reports/ReportMonthDetails/components/ReportEmptyBox/ReportEmptyBox.tsx";
 
 const meta = {
   title: "reports/ReportMonthDetails/ReportEmpty",
   component: ReportEmptyBox,
   tags: ["autodocs"],
-  args: {handleClickAddSchedule: () => alert("add schedule")},
+  args: {
+    handleClickAddSchedule: () => alert("add schedule"),
+    mode: "schedule",
+  },
   argTypes: {},
 } satisfies Meta<typeof ReportEmptyBox>;
 

--- a/src/pages/reports/ReportMonthDetails/components/ReportList/ReportList.tsx
+++ b/src/pages/reports/ReportMonthDetails/components/ReportList/ReportList.tsx
@@ -1,7 +1,7 @@
 import ReportCard from "@pages/reports/ReportMonthDetails/components/ReportCard";
 import ReportCardSkeleton from "@pages/reports/ReportMonthDetails/components/ReportCard/ReportCardSkeleton.tsx";
 import { Button, Stack } from "@mui/material";
-import { CategoryReport, Report } from "@app/types/report.ts";
+import { CategoryReport } from "@app/types/report.ts";
 import { useState } from "react";
 import ReportEmptyBox from "@pages/reports/ReportMonthDetails/components/ReportEmptyBox";
 import { PATH } from "@constants/path.ts";
@@ -32,7 +32,12 @@ function ReportList({
     );
   }
   if (!reportList || reportList.length === 0) {
-    return <ReportEmptyBox handleClickAddSchedule={handleClickAddSchedule} />;
+    return (
+      <ReportEmptyBox
+        handleClickAddSchedule={handleClickAddSchedule}
+        mode="schedule"
+      />
+    );
   }
 
   if (reportList.length < 6) {


### PR DESCRIPTION
- 자산관리 페이지
- 스케쥴 현황 추천 소비 금액을 사용 가능 금액으로 바꾸기
- 자동 로그아웃 시 -> 재로그인할 할 때 user 비우고 시작
- 로그인 실패하면 시작화면으로 돌아가는 문제 해결
- 리포트
  - 소비 금액이 있는데 예측 데이터가 없을 때 소비 예정 금액 설정 표시하기
  - 소비 카테고리 디테일 - 카테고리별 소비 예정 금액 설정하기 추가
  - 리포트 선택 일자 전역 변수로 변경하기

close #undefined